### PR TITLE
Add dockerfile_lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ This list is not exhaustive, contribute to make it so: add your docker resource 
 * [OctoHost](http://www.octohost.io/) (Simple web focused Docker based mini-PaaS server. git push to deploy your websites as needed) by [@octohost](https://github.com/octohost)
 * [Dockly](https://github.com/swipely/dockly): Dockly is a gem made to ease the pain of packaging an application in Docker.
 * [docker-volumes](https://github.com/cpuguy83/docker-volumes) (Docker Volume Manager) by [@cpuguy83](https://github.com/cpuguy83)
+* [dockerfile_lint](https://github.com/redhataccess/dockerfile_lint) (A rule-based 'linter' for Dockerfiles) by [@redhataccess](https://github.com/redhataccess)
  
 ## Useful Images
 * [Base Image](https://github.com/phusion/baseimage-docker) by [@phusion](https://github.com/phusion/)


### PR DESCRIPTION
I thought there were more lint tools than this, but `dockerfile_lint` seems like the only one that approaches having an MVP feature set. It looks like the whole "Dev Tools" section could be reorganized, though, so I'm holding off on creating a "Lint Tools" section.