### PR TITLE
Added docker-alpine to Useful Images section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Securely store your Docker images.
 * [OpenWRT](http://www.zoobab.com/docker-openwrt-image) by [@zoobab](https://github.com/zoobab)
 * [Phusion Docker Hub Account](https://hub.docker.com/u/phusion/)
 * [passenger-docker](https://github.com/phusion/passenger-docker) (Docker base images for Ruby, Python, Node.js and Meteor web apps) by [@phusion](https://github.com/phusion)
+* [docker-alpine](https://github.com/gliderlabs/docker-alpine) (A super small Docker base image using Alpine Linux) by [@gliderlabs](https://github.com/gliderlabs)
 
 ## Docker Files
 * [Dockerfile Project](http://dockerfile.github.io/) : Trusted Automated Docker Builds. Dockerfile Project maintains a central repository of Dockerfile for various popular open source software services runnable on a Docker container.


### PR DESCRIPTION
docker-alpine seems to be the spiritual successor to @progrium's busybox image - the same small size but with  a more powerful package manager. Speaking of which there is now an early deprecation notice on [progrium/busybox](https://github.com/progrium/busybox) in favour of docker-alpine so it may not be necessary to include both in the list.