### PR TITLE
Updating README with a new volume plugin and deployment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ _Source:_ [What is Docker](https://www.docker.com/whatisdocker/)
 * [Conduit](https://github.com/ehazlett/conduit) - Experimental deployment system for Docker by [@ehazlett](https://github.com/ehazlett)
 * [Zodiac](https://github.com/CenturyLinkLabs/zodiac) - A lightweight tool for easy deployment and rollback of dockerized applications. By [@CenturyLinkLabs](https://github.com/CenturyLinkLabs)
 * [rocker-compose](https://github.com/grammarly/rocker-compose) - Docker composition tool with idempotency features for deploying apps composed of multiple containers.
+* [depcon](https://github.com/gondor/depcon) - Depcon is written in Go and allows you to easily deploy Docker containers to Apache Mesos/Marathon, Amazon ECS and Kubernetes.  By [@gonodr](https://github.com/gondor)
 
 ## Hosting for repositories (registries)
 
@@ -360,6 +361,7 @@ Securely store your Docker images.
 * [Convoy](https://github.com/rancher/convoy) - an open-source Docker volume driver that can snapshot, backup and restore Docker volumes anywhere. By [@rancher](https://github.com/rancher)
 * [Azure Files Volume Driver](https://github.com/ahmetalpbalkan/azurefile-dockervolumedriver) - A Docker volume driver that allows you to mount persistent volumes backed by Microsoft Azure File Service. By [@ahmetalpbalkan](https://github.com/ahmetalpbalkan)
 * [Docker Unison](https://github.com/leighmcculloch/docker-unison) A docker volume container using Unison for fast two-way folder sync. Created as an alternative to slow boot2docker volumes on OS X. By [@leighmcculloch](https://github.com/leighmcculloch)
+* [Netshare](https://github.com/gondor/docker-volume-netshare) A Docker volume plugin written in Go that supports mounting NFS, AWS EFS & CIFS volumes within a container. By [@gondor](https://github.com/gondor)
 
 
 ## Useful Images


### PR DESCRIPTION
I have added:

* Netshare a volume plugin for Docker daemon which allows NFS, CIFS and AWS ECS file systems to be mounted within a container.
* Depcon which deploys containers to Apache Mesos/Marathon, AWS ECS & Kubernetes systems

Signed-off-by: Jeremy Unruh <jeremybunruh@gmail.com>