### PR TITLE
Add DevLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ by [@prologic][prologic]
 * [crowdr](https://github.com/polonskiy/crowdr) Tool for managing multiple Docker containers (docker-compose alternative)
 * [ahab](https://github.com/instacart/ahab) Docker event handling with Python
 * [docker-garby](https://github.com/konstruktoid/docker-garby) Docker garbage collection script by [@konstruktoid](https://github.com/konstruktoid).
+* [DevLab](https://github.com/TechnologyAdvice/DevLab) Utility for running containerized development environments
 
 ## Continuous Integration / Continuous Delivery
 


### PR DESCRIPTION
Adds [DevLab](https://github.com/TechnologyAdvice/DevLab) Utility for running containerized development environments