### PR TITLE
Adds Powerline-Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ by [@prologic][prologic]
 * [habitus](https://github.com/cloud66/habitus) A Build Flow Tool for Docker http://www.habitus.io by [@cloud66](https://github.com/cloud66)
 * [Compose Registry](https://www.composeregistry.com) - A very handy search engine for Compose Files
 * [Docker Clean](https://github.com/zzrotdesign/docker-clean) - A scrupt that cleans Docker containers, images and volumes
+* [Powerline-Docker](https://github.com/adrianmo/powerline-docker) - A Powerline segment for showing the status of Docker containers
 
 ## Continuous Integration / Continuous Delivery
 


### PR DESCRIPTION
This Powerline segment shows information about your Docker containers in your terminal, tmux, vim, etc... 

I'm not sure if "Dev Tools" is the right section for this tool. Let me know if you want me to move it somewhere else :)