### PR TITLE
Added Pumba chaos testing tool for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ by [@prologic][prologic]
 * [Watchtower](https://github.com/CenturyLinkLabs/watchtower) - Automatically update running Docker containers by
 [@CenturyLinkLabs][CenturyLinkLabs]
 * [Microservices Continuous Deployment](https://github.com/francescou/docker-continuous-deployment) - Continuous deployment of a microservices application
+* [Pumba](https://github.com/gaia-adm/pumba) - Chaos testing tool for Docker. Can be deployed on Kubernets and CoreOS clusters.
 
 ## Deployment
 


### PR DESCRIPTION
Pumba is a chaos testing tool for Docker. Similar to Netfix Chaos Monkey, but work at container level.