### PR TITLE
Add Katacoda to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ about docker! (Tips: checkout her [dotfiles][jfrazelledotfiles] and her [dockerf
 - [Videos](#videos)
 	- [Main Account](#main-account)
 	- [Useful videos](#useful-videos)
+- [Interactive Learning Environments](#interactive-learning-environments)
 - [Interesting Twitter Accounts](#interesting-twitter-accounts)
 	- [People](#people)
 
@@ -645,6 +646,9 @@ desktop!
 * [SysAdminCasts: Introduction to Docker](https://sysadmincasts.com/episodes/31-introduction-to-docker) (15:49)
 * [Scalable Microservices with Kubernetes](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615) Free Udacity course 
 
+# Interactive Learning Environments
+
+* [Katacoda](https://www.katacoda.com/): Learn Docker using Interactive Browser-Based Labs
 
 # Interesting Twitter Accounts
 


### PR DESCRIPTION
Katacoda is a learning environment for software developers. It hosts free Docker environments and labs for learning Docker, from the foundations of getting started up to running in production and managing security. 