### PR TITLE
Add link to a docker images garbage collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ by [@prologic][prologic]
 * [docker-gulp-seed](https://github.com/cauealves/docker-gulp-seed) - This project is a skeleton for make a simple way to run tasks of Gulp inside a container.
 * [Whale-linter](https://github.com/jeromepin/whale-linter) - A simple and small Dockerfile linter written in Python3+ without dependencies.
 * [docker-make](https://github.com/CtripCloud/docker-make) - build,tag,and push a bunch of related docker images via a single command.
+* [caduc](https://github.com/tjamet/caduc) - A docker garbage collector cleaning stuff you did not use recently
 
 ## Continuous Integration / Continuous Delivery
 


### PR DESCRIPTION
Hi,

I have developed a tool listening docker events and cleaning images (and soon containers and volumes) a user did not run for a customizable period of time.
I thought it could be a good idea to link it here in case anyone would like to use it / evolve it