### PR TITLE
Add dext-docker-registry-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ by [@prologic][prologic]
 * [caduc](https://github.com/tjamet/caduc) - A docker garbage collector cleaning stuff you did not use recently
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - A browser extension for GitHub that makes the image name in a `Dockerfile` clickable and redirect you to the related Docker Hub page.
 * [docker-replay](https://github.com/bcicen/docker-replay) Generate `docker run`command and options from running containers
+* [dext-docker-registry-plugin](https://github.com/vutran/dext-docker-registry-plugin) - Search the Docker Registry with the Dext smart launcher.
 
 ## Continuous Integration / Continuous Delivery
 


### PR DESCRIPTION
I hope this is eligible to be placed within this list. This is a plugin to search the Docker registry for images.

![sep-04-2016 01-58-47](https://cloud.githubusercontent.com/assets/1088312/18229999/8624dac8-7243-11e6-9d20-153ab44e18dc.gif)
