### PR TITLE
Added Dupper Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ by [@prologic][prologic]
 * [docker-volumes](https://github.com/cpuguy83/docker-volumes) (Docker Volume Manager) by [@cpuguy83][cpuguy83]
 * [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint) (A rule-based 'linter' for Dockerfiles) by [@redhataccess](https://github.com/redhataccess)
 * [powerstrip](https://github.com/clusterhq/powerstrip) (A tool for prototyping Docker extensions) by [@clusterhq](https://github.com/clusterhq)
+* [Dupper](https://github.com/athakwani/dupper) (Use git repository as Object Oriented Container. Setup Cloud Development environments with few commands for any git repository) by [@athakwani](https://github.com/athakwani/)
 * [Vagga](https://github.com/tailhook/vagga) (Vagga is a containerisation tool without daemons. It is a fully-userspace container engine inspired by Vagrant and Docker, specialized for development environments.) by [@tailhook](https://github.com/tailhook/)
 * [dockerode](https://github.com/apocas/dockerode) (Not just another Docker Remote API node.js module) by [@apocas](https://github.com/apocas)
 * [go-dockerclient](https://github.com/fsouza/go-dockerclient/) (Go HTTP client for the Docker remote API.) by [@fsouza](https://github.com/fsouza/)


### PR DESCRIPTION
With Dupper use git project as object oriented container. Setup cloud development environment for any project with few commands. Visit www.dupper.co for documentation.