### PR TITLE
Add clusterdock to list of orchestration projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ Securely store your Docker images.
 * [blimp](https://github.com/tubesandlube/blimp) - Uses Docker Machine to easily move a container from one Docker host to another, show containers running against all of your hosts, replicate a container across multiple hosts and more. By [@defermat](https://github.com/defermat) and [@schvin](https://github.com/schvin)
 * [Capitan](https://github.com/byrnedo/capitan) - Composable docker orchestration with added scripting support by [@byrnedo](https://github.com/byrnedo).
 * [CloudSlang](http://www.cloudslang.io/) - CloudSlang is a workflow engine to create Docker process automation
+* [clusterdock](https://github.com/clusterdock/framework) - Docker container orchestration to enable the testing of long-running cluster deployments.
 * [ContainerShip](https://github.com/containership/containership) A simple container management platform [containership]
 * [CoreOS][coreos] - Linux for Massive Server Deployments https://coreos.com/
 * [Crane](https://github.com/Dataman-Cloud/crane) - Control plane based on docker built-in swarm [@Dataman-Cloud](https://github.com/Dataman-Cloud)


### PR DESCRIPTION
Originally developed at Cloudera (as described in [this blog post](https://blog.cloudera.com/blog/2016/08/multi-node-clusters-with-cloudera-quickstart-for-docker/)), the clusterdock project is now also in use to [enable testing of Apache HBase](https://issues.apache.org/jira/browse/HBASE-12721).