### PR TITLE
Docker-Alertd: Send Alerts Based on Container Usage/Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Services to securely store your Docker images.
 * [Seagull](https://github.com/tobegit3hub/seagull) - Friendly Web UI to monitor docker daemon. by [@tobegit3hub](https://github.com/tobegit3hub)
 * [Zabbix Docker module](https://github.com/monitoringartist/Zabbix-Docker-Monitoring) - Zabbix module that provides discovery of running containers, CPU/memory/blk IO/net container metrics. Systemd Docker and LXC execution driver is also supported. It's a dynamically linked shared object library, so its performance is (~10x) better, than any script solution.
 * [Zabbix Docker](https://github.com/gomex/docker-zabbix) - Monitor containers automatically using zabbix LLD feature.
+* [Docker-Alertd](https://github.com/deltaskelta/docker-alertd) - Monitor and send alerts based on docker container resource usage/statistics
 
 ### Monitoring & Logging Services
 * [AppDynamics](https://www.appdynamics.com/community/exchange/extension/docker-monitoring-extension/) - AppDynamics gives enterprises real-time insights into application performance, user performance, and business performance so they can move faster in an increasingly sophisticated, software-driven world.


### PR DESCRIPTION
docker-alertd:
- is extremely lightweight
- monitors containers based on docker stats API
- monitors CPU usage, memory usage, minimum # of container PIDS
- sends email alerts when limits are reached
- uses a simple json conf file