### PR TITLE
Add packer for image builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Services to securely store your Docker images.
 * [flyimg](http://flyimg.io/) - Docker image resizing, cropping, and compression on the fly.
 * [habitus](https://github.com/cloud66/habitus) - A Build Flow Tool for Docker http://www.habitus.io by [@cloud66](https://github.com/cloud66)
 * [MicroBadger][microbadger] - Analyze the contents of images and add metadata labels
+* [packer](https://www.packer.io/docs/builders/docker.html) - Hashicorp tool to build machine images including docker image integrated with configuration management tools like chef, puppet, ansible
 * [portainer](https://github.com/duedil-ltd/portainer) - Apache Mesos framework for building Docker images by [@duedil-ltd](https://github.com/duedil-ltd)
 * [rocker](https://github.com/grammarly/rocker) - Extended Dockerfile builder. Supports multiple FROMs, MOUNTS, templates, etc. by [grammarly](grammarly).
 * [SkinnyWhale](https://github.com/djosephsen/skinnywhale) Skinnywhale helps you make smaller (as in megabytes) Docker containers.


### PR DESCRIPTION
Packer's [Docker builder](https://www.packer.io/docs/builders/docker.html) can be used with various provisioners starting from shell to configuration management tools like [chef](https://www.chef.io/chef/), [puppet](https://puppet.com/), [ansible](https://www.ansible.com/), and [salt](https://saltstack.com/) which can handle more complex and flexible docker image configuration compared to Dockerfile.