### PR TITLE
Add docker-maven-plugin to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Gradle Docker plugin](https://github.com/gesellix/gradle-docker-plugin) - A Docker remote api plugin for Gradle by [@gesellix][gesellix]
 * [powerstrip](https://github.com/clusterhq/powerstrip) - A tool for prototyping Docker extensions by [@clusterhq](https://github.com/clusterhq)
 * [sbt-docker-compose](https://github.com/Tapad/sbt-docker-compose) - Integrates Docker Compose functionality into sbt by [@kurtkopchik](https://github.com/kurtkopchik/)
+* [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) - A Maven plugin for building and pushing Docker images by [@spotify](https://github.com/spotify/)
 
 ## Development Environments
 * [DevLab](https://github.com/TechnologyAdvice/DevLab) - Utility for running containerized development environments

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [bocker](https://github.com/p8952/bocker) (1) - Docker implemented in 100 lines of bash by [p8952](https://github.com/p8952)
 * [construi](https://github.com/lstephen/construi) - Run your builds inside a Docker defined environment by [@lstephen](https://github.com/lstephen)
 * [Docker Client for JVM](https://github.com/gesellix/docker-client) - A Docker remote api client library for the JVM, written in Groovy by [@gesellix][gesellix]
+* [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) - A Maven plugin for building and pushing Docker images by [@spotify](https://github.com/spotify/)
 * [Docker-PowerShell](https://github.com/Microsoft/Docker-PowerShell) - PowerShell Module for Docker
 * [Docker.DotNet](https://github.com/Microsoft/Docker.DotNet) - C#/.NET HTTP client for the Docker remote API by [@ahmetalpbalkan](ahmetalpbalkan)
 * [dockerode](https://github.com/apocas/dockerode) - Docker Remote API node.js module by [@apocas](https://github.com/apocas)
@@ -156,7 +157,6 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Gradle Docker plugin](https://github.com/gesellix/gradle-docker-plugin) - A Docker remote api plugin for Gradle by [@gesellix][gesellix]
 * [powerstrip](https://github.com/clusterhq/powerstrip) - A tool for prototyping Docker extensions by [@clusterhq](https://github.com/clusterhq)
 * [sbt-docker-compose](https://github.com/Tapad/sbt-docker-compose) - Integrates Docker Compose functionality into sbt by [@kurtkopchik](https://github.com/kurtkopchik/)
-* [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) - A Maven plugin for building and pushing Docker images by [@spotify](https://github.com/spotify/)
 
 ## Development Environments
 * [DevLab](https://github.com/TechnologyAdvice/DevLab) - Utility for running containerized development environments


### PR DESCRIPTION
Added [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) from [@spotify](https://github.com/spotify).

As you can see in their README, it provides a simple way to create a Docker image with artifacts built from a Maven project.