### PR TITLE
Removed Octohost project

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ Services to securely store your Docker images.
 * [Dusty](http://dusty.gc.com/) - Managed Docker development environments on OS X
 * [FuGu](https://github.com/mattes/fugu) - Docker run wrapper without orchestration by [@mattes](https://github.com/mattes)
 * [libcompose](https://github.com/docker/libcompose) - Go library for Docker Compose.
-* [OctoHost](http://octohost.io/) - Simple web focused Docker based mini-PaaS server. git push to deploy your websites as needed) by [@octohost](https://github.com/octohost)
 * [percheron][percheron] - Organise your Docker containers with muscle and intelligence by [@ashmckenzie](https://github.com/ashmckenzie)
 * [Shutit](http://ianmiell.github.io/shutit/) - Tool for building and maintaining complex Docker deployments by [@ianmiell][ianmiell]
 * [subuser](http://subuser.org) - Makes it easy to securely and portably run graphical desktop applications in Docker


### PR DESCRIPTION
<!-- Congrats on creating an Awesome Docker entry! 🎉 -->


<!-- Please fill in the below placeholders -->

[Octohost](https://github.com/octohost/octohost) project is no longer actively maintained


# By submitting this pull request I confirm I've read and complied with the below requirements.

**Please read it multiple times. I spent a lot of time on these guidelines and most people miss a lot.**

- I have read and understood the [contribution guidelines](https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md)

- The project submitted is conform to the quality standards outlined in the [contribution guidelines](https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md)

- Go to the [contribution guidelines](https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md) and read it again.
