### PR TITLE
Modfied 'Where to start' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ All the links are monitored and tested with [awesome_bot](https://github.com/dkh
 _Source:_ [What is Docker](https://www.docker.com/what-docker)
 
 # Where to start?
-* [10-minute Interactive Tutorial](https://docs.docker.com/docker-for-mac/)
-* [Docker Training](http://training.docker.com/)
+* [Play With Docker](http://training.play-with-docker.com/) - A great way to get started with Docker from beginner to advanced users. Docker runs directly in your browser.
+* [Docker Documentation](https://docs.docker.com/)
+* [Docker Training](http://training.docker.com/) - Includes a free self-paced hands-on tutorial (free registration required or sign-in with DockerHub ID)
 * Read this complete article: [Basics – Docker, Containers, Hypervisors, CoreOS](http://etherealmind.com/basics-docker-containers-hypervisors-coreos/)
 * Watch the video: [Docker for Developers][docker4dev] (54:26) by [@jpetazzo][jpetazzo]
 * [Docker Jumpstart](https://github.com/odewahn/docker-jumpstart/): a quick introduction
 * [Docker Curriculum](https://prakhar.me/docker-curriculum/): A comprehensive tutorial for getting started with Docker. Teaches how to use Docker and deploy dockerized apps on AWS with Elastic Beanstalk and Elastic Container Service.
-* [Install Docker on your machine](https://github.com/wsargent/docker-cheat-sheet#installation) and play with a few [Useful Images](#useful-images)
 * Try [Panamax: Docker Management for Humans][panamax.io] It will install a CoreOS VM with VirtualBox and has nice front end
-* [Install Docker Toolbox](https://www.docker.com/products/docker-toolbox) Docker Toolbox is an installer to quickly and easily install and setup a Docker environment on your computer. Available for both Windows and Mac, the Toolbox installs Docker Client, Machine, Compose (Mac only), Kitematic and VirtualBox.
+* [Docker Toolbox](https://docs.docker.com/toolbox/overview/) - It's a **legacy desktop application** for quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/).
 * Check out [Docker Cheat Sheet][docker-cheat-sheet] by [@wsargent][wsargent] __MUST SEE__
 * [Project Web Dev][projwebdev] : (Article series) How to create your own website based on Docker
 * [Docker Containers on the desktop][jessblog] by [@jessfraz][jessfraz]) The **funniest way** to learn about docker! (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
@@ -93,7 +93,6 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
 * [How to Whale](https://howtowhale.com/) Learn Docker in your web browser, no setup or installation required.
 * [Docker for all - Developers, Testers, DevOps, Product Owners + Videos](https://github.com/machzqcq/docker-for-all) Docker Training Videos for all
-* [Play With Docker](http://labs.play-with-docker.com/) - A great way to get started with Docker. Docker runs directly in your browser.
 * [Katacoda](https://www.katacoda.com/): Learn Docker using Interactive Browser-Based Labs
 
 # Where to start? (Windows)

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Docker Jumpstart](https://github.com/odewahn/docker-jumpstart/): a quick introduction
 * [Docker Curriculum](https://prakhar.me/docker-curriculum/): A comprehensive tutorial for getting started with Docker. Teaches how to use Docker and deploy dockerized apps on AWS with Elastic Beanstalk and Elastic Container Service.
 * Try [Panamax: Docker Management for Humans][panamax.io] It will install a CoreOS VM with VirtualBox and has nice front end
-* [Docker Toolbox](https://docs.docker.com/toolbox/overview/) - It's a **legacy desktop application** for quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/).
+* [Docker Toolbox](https://docs.docker.com/toolbox/overview/) - It's a **legacy desktop application** for quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac][docker-for-mac] or [Docker for Windows][docker-for-windows].
 * Check out [Docker Cheat Sheet][docker-cheat-sheet] by [@wsargent][wsargent] __MUST SEE__
 * [Project Web Dev][projwebdev] : (Article series) How to create your own website based on Docker
 * [Docker Containers on the desktop][jessblog] by [@jessfraz][jessfraz]) The **funniest way** to learn about docker! (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
 * [Container Hacks and Fun Images][jessvid] by [@jessfraz][jessfraz] @ DockerCon 2015 **MUST WATCH VIDEO** (38:50)
 * [Learn Docker](https://github.com/dwyl/learn-docker) Full environment set up, screenshots, step-by-step tutorial and more resources (video, articles, cheat sheets) by [@dwyl](https://github.com/dwyl)
 * [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
-* [How to Whale](https://howtowhale.com/) Learn Docker in your web browser, no setup or installation required.
+* [How to Whale](https://github.com/carolynvs/howtowhale) - Learn Docker in your web browser, no setup or installation required by [@carolynvs](https://github.com/carolynvs).
 * [Docker for all - Developers, Testers, DevOps, Product Owners + Videos](https://github.com/machzqcq/docker-for-all) Docker Training Videos for all
 * [Katacoda](https://www.katacoda.com/): Learn Docker using Interactive Browser-Based Labs
 
@@ -489,7 +489,7 @@ Services to securely store your Docker images.
 * [Blog](http://progrium.com/blog/) of [@progrium][progrium]
 * [Blog](http://sebgoa.blogspot.be/) of [@sebgoa][sebgoa]
 * [Blog](https://blog.codeship.com/) of [@codeship](https://github.com/codeship)
-* [Blog](https://blog.jessfraz.com/) of [@frazelledazzell][jessfraz]
+* [Blog](https://blog.jessfraz.com/) of [@jessfraz][jessfraz]
 * [Container solutions](http://container-solutions.com/blog/)
 * [Container42](http://container42.com/)
 * [Docker Cheat Sheet](http://docker.jens-piegsa.com) by [@JensPiegsa][JensPiegsa] *(updated for Docker 1.13)*
@@ -606,6 +606,7 @@ Services to securely store your Docker images.
 
 [ahmetalpbalkan]: https://github.com/ahmetalpbalkan
 [alpine]: https://github.com/gliderlabs/docker-alpine
+[arun-gupta]: https://github.com/arun-gupta
 [blockbridge]: https://github.com/blockbridge
 [brooklyn]: http://brooklyn.apache.org/
 [calico]: https://github.com/projectcalico/calicoctl
@@ -620,6 +621,8 @@ Services to securely store your Docker images.
 [docker-compose]: https://docs.docker.com/compose/
 [docker-quick-ref]: https://github.com/dimonomid/docker-quick-ref
 [docker]: https://github.com/docker
+[docker-for-mac]: https://docs.docker.com/docker-for-mac/
+[docker-for-windows]: https://docs.docker.com/docker-for-windows/
 [docker4dev]: https://www.youtube.com/watch?v=FdkNAjjO5yQ
 [dokku]: https://github.com/dokku/dokku
 [editREADME]: https://github.com/veggiemonk/awesome-docker/edit/master/README.md

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Services to securely store your Docker images.
 ## Newsletter
 * [Docker Team](https://www.docker.com/)
 * [Shippable](http://blog.shippable.com/)
-* [WebOps weekly](http://webopsweekly.com/)
+* [WebOps weekly](https://webopsweekly.com/)
 * [DevOpsLinks](http://devopslinks.com)
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [A Comparative Study of Docker Engine on Windows Server vs Linux](http://collabnix.com/archives/1965) Comparing the feature sets and implementations of Docker on Windows and Linux
 * [Docker with Microsoft SQL 2016 + ASP.NET](http://blog.alexellis.io/docker-does-sql2016-aspnet/) Demonstration running ASP.NET and SQL Server workloads in Docker
 * [Running a Legacy ASP.NET App in a Windows Container](https://blog.sixeyed.com/dockerizing-nerd-dinner-part-1-running-a-legacy-asp-net-app-in-a-windows-container/) Steps for Dockerizing a legacy ASP.NET app and runnning as a Windows container
-* [Exploring ASP.NET Core with Docker in both Linux and Windows Containers](http://www.hanselman.com/blog/ExploringASPNETCoreWithDockerInBothLinuxAndWindowsContainers.aspx) Running ASP.NET Core apps in Linux and Windows containers, using [Docker for Windows](https://docs.docker.com/docker-for-windows/)
+* [Exploring ASP.NET Core with Docker in both Linux and Windows Containers](http://www.hanselman.com/blog/ExploringASPNETCoreWithDockerInBothLinuxAndWindowsContainers.aspx) Running ASP.NET Core apps in Linux and Windows containers, using [Docker for Windows][docker-for-windows]
 
 ----
 


### PR DESCRIPTION
In my opinion, [Play with Docker](http://training.play-with-docker.com/) is a really good start to get to know about Docker. That's why it's listed first.

Removed:
- [Install Docker on your machine](https://github.com/wsargent/docker-cheat-sheet#installation) - because few lines below by the same repo author (wsargent), [Docker Cheat Sheet](https://github.com/wsargent/docker-cheat-sheet) is listed where an installation guide is already included.

To be removed?
- [How to Whale](https://howtowhale.com/) - As we know, this website is depending on Carina which is down since April 18, 2017. Should the website be removed from the list or linked at least to [https://github.com/carolynvs/howtowhale](https://github.com/carolynvs/howtowhale)?