### PR TITLE
Remove obsolete Orchard entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,6 @@ Services to securely store your Docker images.
 * [Hyper_](https://hyper.sh/) - Secure container hosting service with "nano-containers" and per-second billing.
 * [IBM Bluemix Container Service](https://console.bluemix.net/docs/containers/container_index.html) - Run Docker containers in a hosted cloud environment on IBM Bluemix.
 * [OpenShift Dedicated](https://www.openshift.com/dedicated/index.html) - A hosted [OpenShift][openshift] cluster for running your Docker containers managed by Red Hat.
-* [Orchard](https://www.orchardup.com/) (part of Docker Inc) - Get a Docker host in the cloud, instantly.
 * [Sloppy.io](https://sloppy.io/) - all-in-one solution for container deployment and hosting – made and hosted in Germany
 * [Triton](https://www.joyent.com/) - Elastic container-native infrastructure by Joyent.
 


### PR DESCRIPTION
Orchard closed down on October 23rd 2014, so it's time to remove it. See https://www.orchardup.com/blog/orchard-is-joining-docker .

# By submitting this pull request I confirm I've read and complied with the [contribution guidelines](https://github.com/veggiemonk/awesome-docker/blob/master/CONTRIBUTING.md), I read them multiple times :+1:.
