### PR TITLE
Fix redirect for docker-containerizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Docker EE is on the same code base as Docker CE, so also built from Moby, with c
 * [Kubernetes](https://github.com/kubernetes/kubernetes) - Open source orchestration system for Docker containers by Google
 * [Mantl](https://github.com/mantl/mantl) - Mantl is a modern platform for rapidly deploying globally distributed services
 * [Marathon](https://mesosphere.github.io/marathon/docs/) - Marathon is a private PaaS built on Mesos. It automatically handles hardware or software failures and ensures that an app is "always on"
-* [Mesos](https://mesos.apache.org/documentation/latest/docker-containerizer) - Resource/Job scheduler for containers, VM's and physical hosts [@apache](https://mesos.apache.org/)
+* [Mesos](https://mesos.apache.org/documentation/latest/docker-containerizer/) - Resource/Job scheduler for containers, VM's and physical hosts [@apache](https://mesos.apache.org/)
 * [Mesosphere DC/OS 💲](https://mesosphere.com/product/) - Integrated platform for data and containers built on Apache Mesos by [@mesosphere](https://mesosphere.com)
 * [Nebula](https://github.com/nebula-orchestrator) - A Docker orchestration tool designed to manage massive scale distributed clusters.
 * [Nomad](https://github.com/hashicorp/nomad) - Easily deploy applications at any scale. A Distributed, Highly Available, Datacenter-Aware Scheduler by [@hashicorp][hashicorp]


### PR DESCRIPTION
Fixes failing ci test:

    [L206] 301 https://mesos.apache.org/documentation/latest/docker-containerizer  → https://mesos.apache.org/documentation/latest/docker-containerizer/