### PR TITLE
Remove CLI and web based tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ All the links are monitored and tested with [awesome_bot](https://github.com/dkh
 - Abandoned 💀
 - Beta 🤕
 - Monetized 💲
-- Terminal 🤓
-- Web Based 😎
 - Website 🖥
 
 # What is Docker?


### PR DESCRIPTION
According to #446, the tagging needs a little tweaking. 
The CLI and web based don't bring any additional value. The description should state if the tool is a CLI or a web app.

Tell us what you think...