### PR TITLE
Clarify the tagging purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ All the links are monitored and tested with [awesome_bot](https://github.com/dkh
 	- [Russian](#russian)
 
 # Legend
-- Abandoned 💀
-- Beta 🤕
-- Monetized 💲
-- Website 🖥
+- Abandoned :skull:
+- Beta :construction:
+- Monetized :heavy_dollar_sign:
 
 # What is Docker?
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -33,5 +33,5 @@ Links will be tested with [awesome_bot](https://github.com/dkhamsing/awesome_bot
 - ORDER: The entries are in lexical order (English letter order) 
 - LABEL (Optional): Add one of the following icons next to the project name like ```[Name](Link) :icon: - Description.```
   - :heavy_dollar_sign: indicates if one needs a paying subscription to use the project.
-  - :construction: indicates that the project is in work in progress/beta phase.
+  - :construction: indicates that the project is a work in progress/beta release.
   - :skull: indicates that the project is obsolete, but still worth mentioning it.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -31,8 +31,7 @@ Links will be tested with [awesome_bot](https://github.com/dkhamsing/awesome_bot
   - `Description.` should end with a full stop/period
   - For GitHub repositories, add the name of the author with a link to its GitHub account after the description, like `By [@author](GitHub account)`
 - ORDER: The entries are in lexical order (English letter order) 
-- LABEL (Optional)
-  - 💲 indicates if one needs a paying subscription to use the project.
-  <br>Add 💲 next to the project name like `[Name 💲](Link)`
-  - 🤕 indicates that the project is in beta phase.
-  <br>Add 🤕 next to the project name like `[Name 🤕](Link)`
+- LABEL (Optional): Add one of the following icons next to the project name like ```[Name](Link) :icon: - Description.```
+  - :heavy_dollar_sign: indicates if one needs a paying subscription to use the project.
+  - :construction: indicates that the project is in work in progress/beta phase.
+  - :skull: indicates that the project is obsolete, but still worth mentioning it.


### PR DESCRIPTION
According to issue #446, we now have 3 tagging icons namely
:heavy_dollar_sign: for commercial tools
:construction: for beta/WIP projects
:skull: for obsolete projects

--
close #446 