### PR TITLE
remove `style.min.css`

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
   <link rel="icon" type="image/png" href="/awesome-docker/favicon.png">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="/awesome-docker/style.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/emojione@3.1.2/extras/css/emojione.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.7.2/showdown.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/emojione@3.1.2/lib/js/emojione.min.js"></script>


### PR DESCRIPTION
Minified stylesheet style.min.css was introduced at [1] as replacement
of unminified version `style.css`.  Unfortunately at [2] `style.css` was
re-introduced in addition to minified version. Consequently both
versions where requested.

[1] e946c57 - meta tags and min css
[2] 09ae203 - Fix Table of Content

Closes #453.