### PR TITLE
Cleanup tips section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,11 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 # Where to start?
 * [Basics – Docker, Containers, Hypervisors, CoreOS](http://etherealmind.com/basics-docker-containers-hypervisors-coreos/)
 * [Dive Into Docker: From "What is Docker?" to "Hello World"](https://www.youtube.com/watch?v=XeSD17YRijk&list=PL-v3vdeWVEsXT-u0JDQZnM90feU3NE3v8) (60:25) by [@nickjanetakis][nickjanetakis]
-* [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
-* [Docker Containers on the Desktop][jessblog] - The **funniest way** to learn about docker by [@jessfraz][jessfraz] who also gave a [presentation][jessvid] about it @ DockerCon 2015 (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
 * [Docker Curriculum](https://docker-curriculum.com): A comprehensive tutorial for getting started with Docker. Teaches how to use Docker and deploy dockerized apps on AWS with Elastic Beanstalk and Elastic Container Service.
 * [Docker Documentation](https://docs.docker.com/)
 * [Docker for all - Developers, Testers, DevOps, Product Owners + Videos](https://github.com/machzqcq/docker-for-all) Docker Training Videos for all
 * [Docker Jumpstart](https://github.com/odewahn/docker-jumpstart/): a quick introduction
-* [Docker Toolbox](https://docs.docker.com/toolbox/overview/) - It's a **legacy desktop application** for quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac][docker-for-mac] or [Docker for Windows][docker-for-windows].
+* [Docker Toolbox](https://docs.docker.com/toolbox/overview/) :skull: - Quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac][docker-for-mac] or [Docker for Windows][docker-for-windows].
 * [Docker Training](https://training.docker.com/) - Includes a free self-paced hands-on tutorial (free registration required or sign-in with DockerHub ID)
 * [Katacoda](https://www.katacoda.com/): Learn Docker using Interactive Browser-Based Labs
 * [Learn Docker](https://github.com/dwyl/learn-docker) Full environment set up, screenshots, step-by-step tutorial and more resources (video, articles, cheat sheets) by [@dwyl](https://github.com/dwyl)
@@ -544,11 +542,8 @@ Services to securely store your Docker images.
 # Useful Resources
 
 * __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__ 
-* Blogs [by @nickjanetakis](https://nickjanetakis.com/blog/tag/docker) [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/)
-* [Container solutions](http://container-solutions.com/blog/)
-* [Container42](http://container42.com/)
+* Blogs [by @nickjanetakis](https://nickjanetakis.com/blog/tag/docker) [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/) * [@Container42](http://container42.com/) [Container solutions](http://container-solutions.com/blog/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
-* [Docker vs. VMs? Combining Both for Cloud Portability Nirvana](https://www.rightscale.com/blog/cloud-management-best-practices/docker-vs-vms-combining-both-cloud-portability-nirvana)
 * [Docker Weekly](https://blog.docker.com/docker-weekly-archives/) Huge resource
 
 ## Awesome Lists
@@ -562,10 +557,13 @@ Services to securely store your Docker images.
 
 ## Good Tips
 
+* [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
+* [Docker Containers on the Desktop][jessblog] - The **funniest way** to learn about docker by [@jessfraz][jessfraz] who also gave a [presentation][jessvid] about it @ DockerCon 2015 (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)
 * [GUI Apps with Docker](http://fabiorehm.com/blog/2014/09/11/running-gui-apps-with-docker/) by [@fgrehm][fgrehm]
+* [Docker vs. VMs? Combining Both for Cloud Portability Nirvana](https://www.rightscale.com/blog/cloud-management-best-practices/docker-vs-vms-combining-both-cloud-portability-nirvana)
 
 
 ## Raspberry Pi & ARM

--- a/README.md
+++ b/README.md
@@ -357,14 +357,17 @@ Docker EE is on the same code base as Docker CE, so also built from Moby, with c
 * [Dockerfile Generator](http://jrruethe.github.io/blog/2015/09/20/dockerfile-generator/)
 * [Vektorcloud](https://github.com/vektorcloud) - A collection of minimal, Alpine-based Docker images
 
-Examples by: [@crosbymichael](https://github.com/crosbymichael/Dockerfiles)
-[@pandrew](https://github.com/pandrew/dockerfiles)
-[@vimagick](https://github.com/vimagick/dockerfiles)
-[@ondrejmo](https://github.com/ondrejmo/Dockerfiles)
-[@arun-gupta](https://github.com/arun-gupta/docker-images)
-[@llitfkitfk](https://github.com/llitfkitfk/docker-compose-demo)
-[@komljen](https://github.com/komljen/dockerfile-examples)
-[@kstaken](https://github.com/kstaken/dockerfile-examples)
+Examples by:
+* [@arun-gupta](https://github.com/arun-gupta/docker-images)
+* [@crosbymichael](https://github.com/crosbymichael/Dockerfiles)
+* [@jessfraz](https://github.com/jessfraz/Dockerfiles)
+* [@komljen](https://github.com/komljen/dockerfile-examples)
+* [@kstaken](https://github.com/kstaken/dockerfile-examples)
+* [@llitfkitfk](https://github.com/llitfkitfk/docker-compose-demo)
+* [@ondrejmo](https://github.com/ondrejmo/Dockerfiles)
+* [@pandrew](https://github.com/pandrew/dockerfiles)
+* [@vimagick](https://github.com/vimagick/dockerfiles)
+
 
 ### Linter
 
@@ -542,9 +545,22 @@ Services to securely store your Docker images.
 # Useful Resources
 
 * __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__ 
-* Blogs [by @nickjanetakis](https://nickjanetakis.com/blog/tag/docker) [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/) * [@Container42](http://container42.com/) [Container solutions](http://container-solutions.com/blog/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
 * [Docker Weekly](https://blog.docker.com/docker-weekly-archives/) Huge resource
+
+Blogs by 
+* [@codeship](https://blog.codeship.com/)  
+* [@crosbymichael](http://crosbymichael.com/) 
+* [@jessfraz](https://blog.jessfraz.com/) 
+* [@gliderlabs](https://gliderlabs.com/devlog/) 
+* [@jpetazzo](http://jpetazzo.github.io/) 
+* [@jwilder](http://jasonwilder.com/) 
+* [@nickjanetakis](https://nickjanetakis.com/blog/tag/docker) 
+* [@progrium](http://progrium.com/blog/) 
+* [@sebgoa](http://sebgoa.blogspot.be/) 
+* [Container42](http://container42.com/) 
+* [Container solutions](http://container-solutions.com/blog/)
+
 
 ## Awesome Lists
 
@@ -558,7 +574,7 @@ Services to securely store your Docker images.
 ## Good Tips
 
 * [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
-* [Docker Containers on the Desktop][jessblog] - The **funniest way** to learn about docker by [@jessfraz][jessfraz] who also gave a [presentation][jessvid] about it @ DockerCon 2015 (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
+* [Docker Containers on the Desktop][jessblog] - The **funniest way** to learn about docker by [@jessfraz][jessfraz] who also gave a [presentation][jessvid] about it @ DockerCon 2015
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)

--- a/README.md
+++ b/README.md
@@ -548,7 +548,6 @@ Services to securely store your Docker images.
 * [Container solutions](http://container-solutions.com/blog/)
 * [Container42](http://container42.com/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
-* [Docker Kubernetes Lab Handbook](https://github.com/xiaopeng163/docker-k8s-lab)
 * [Docker vs. VMs? Combining Both for Cloud Portability Nirvana](https://www.rightscale.com/blog/cloud-management-best-practices/docker-vs-vms-combining-both-cloud-portability-nirvana)
 * [Docker Weekly](https://blog.docker.com/docker-weekly-archives/) Huge resource
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Learn Docker](https://github.com/dwyl/learn-docker) Full environment set up, screenshots, step-by-step tutorial and more resources (video, articles, cheat sheets) by [@dwyl](https://github.com/dwyl)
 * [Play With Docker](http://training.play-with-docker.com/) - PWD is a great way to get started with Docker from beginner to advanced users. Docker runs directly in your browser.
 * [Play With Moby](http://play-with-moby.com/) - PWM is a web based Moby playground which allows you to try different components of the platform in seconds. It gives you the experience of having a free Alpine Linux Virtual Machine in the cloud where you can build and run Moby projects and even create clusters to experiment.
-* **Cheatsheets** by * [@wsargent][docker-cheat-sheet] [@JensPiegsa](http://docker.jens-piegsa.com) [@eon01](https://github.com/eon01/DockerCheatSheet) [@dimonomid][docker-quick-ref] (PDF)
+
+**Cheatsheets** by 
+* [@eon01](https://github.com/eon01/DockerCheatSheet)
+* [@dimonomid][docker-quick-ref] (PDF)
+* [@JensPiegsa](http://docker.jens-piegsa.com) 
+* [@wsargent][docker-cheat-sheet] 
 
 # Where to start? (Windows)
 * [Windows Containers Quick Start](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/index) Overview of Windows containers, drilling down to Quick Starts for Windows 10 and Windows Server 2016

--- a/README.md
+++ b/README.md
@@ -543,21 +543,14 @@ Services to securely store your Docker images.
 
 # Useful Resources
 
-* [Blog](http://crosbymichael.com/) of [@crosbymichael][crosbymichael]
-* [Blog](https://gliderlabs.com/devlog/) of [@gliderlabs][gliderlabs]
-* [Blog](http://jasonwilder.com/) of [@jwilder][jwilder]
-* [Blog](http://jpetazzo.github.io/) of [@jpetazzo][jpetazzo]
-* [Blog](http://progrium.com/blog/) of [@progrium][progrium]
-* [Blog](http://sebgoa.blogspot.be/) of [@sebgoa][sebgoa]
-* [Blog](https://blog.codeship.com/) of [@codeship](https://github.com/codeship)
-* [Blog](https://blog.jessfraz.com/) of [@jessfraz][jessfraz]
+* __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__ 
+* Blogs [by @nickjanetakis][nickjanetakis] [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/)
 * [Container solutions](http://container-solutions.com/blog/)
 * [Container42](http://container42.com/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
 * [Docker Kubernetes Lab Handbook](https://github.com/xiaopeng163/docker-k8s-lab)
 * [Docker vs. VMs? Combining Both for Cloud Portability Nirvana](https://www.rightscale.com/blog/cloud-management-best-practices/docker-vs-vms-combining-both-cloud-portability-nirvana)
 * [Docker Weekly](https://blog.docker.com/docker-weekly-archives/) Huge resource
-* __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__
 
 ## Awesome Lists
 
@@ -570,7 +563,7 @@ Services to securely store your Docker images.
 
 ## Good Tips
 
-* [50+ Docker related tips, tricks and tutorials](https://nickjanetakis.com/blog/tag/docker) by [@nickjanetakis][nickjanetakis]
+* [50+ Docker related tips, tricks and tutorials](https://nickjanetakis.com/blog/tag/docker) by [
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Services to securely store your Docker images.
 # Useful Resources
 
 * __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__ 
-* Blogs [by @nickjanetakis][nickjanetakis] [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/)
+* Blogs [by @nickjanetakis](https://nickjanetakis.com/blog/tag/docker) [@crosbymichael](http://crosbymichael.com/) [@gliderlabs](https://gliderlabs.com/devlog/) [@jwilder](http://jasonwilder.com/) [@jpetazzo](http://jpetazzo.github.io/) [@progrium](http://progrium.com/blog/) [@sebgoa](http://sebgoa.blogspot.be/) [@codeship](https://blog.codeship.com/) [@jessfraz](https://blog.jessfraz.com/)
 * [Container solutions](http://container-solutions.com/blog/)
 * [Container42](http://container42.com/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
@@ -562,7 +562,6 @@ Services to securely store your Docker images.
 
 ## Good Tips
 
-* [50+ Docker related tips, tricks and tutorials](https://nickjanetakis.com/blog/tag/docker) by [
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Basics – Docker, Containers, Hypervisors, CoreOS](http://etherealmind.com/basics-docker-containers-hypervisors-coreos/)
 * [Dive Into Docker: From "What is Docker?" to "Hello World"](https://www.youtube.com/watch?v=XeSD17YRijk&list=PL-v3vdeWVEsXT-u0JDQZnM90feU3NE3v8) (60:25) by [@nickjanetakis][nickjanetakis]
 * [Docker Caveats](http://docker-saigon.github.io/post/Docker-Caveats/) What You Should Know About Running Docker In Production (written 11 APRIL 2016) __MUST SEE__
-* [Docker Cheat Sheet][docker-cheat-sheet] by [@wsargent][wsargent] __MUST SEE__
 * [Docker Containers on the Desktop][jessblog] - The **funniest way** to learn about docker by [@jessfraz][jessfraz] who also gave a [presentation][jessvid] about it @ DockerCon 2015 (Tips: checkout her [dotfiles][jessfrazdotfiles] and her [dockerfiles][jessfrazdockerfiles])
 * [Docker Curriculum](https://docker-curriculum.com): A comprehensive tutorial for getting started with Docker. Teaches how to use Docker and deploy dockerized apps on AWS with Elastic Beanstalk and Elastic Container Service.
 * [Docker Documentation](https://docs.docker.com/)
@@ -100,6 +99,7 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Learn Docker](https://github.com/dwyl/learn-docker) Full environment set up, screenshots, step-by-step tutorial and more resources (video, articles, cheat sheets) by [@dwyl](https://github.com/dwyl)
 * [Play With Docker](http://training.play-with-docker.com/) - PWD is a great way to get started with Docker from beginner to advanced users. Docker runs directly in your browser.
 * [Play With Moby](http://play-with-moby.com/) - PWM is a web based Moby playground which allows you to try different components of the platform in seconds. It gives you the experience of having a free Alpine Linux Virtual Machine in the cloud where you can build and run Moby projects and even create clusters to experiment.
+* **Cheatsheets** by * [@wsargent][docker-cheat-sheet] [@JensPiegsa](http://docker.jens-piegsa.com) [@eon01](https://github.com/eon01/DockerCheatSheet) [@dimonomid][docker-quick-ref] (PDF)
 
 # Where to start? (Windows)
 * [Windows Containers Quick Start](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/index) Overview of Windows containers, drilling down to Quick Starts for Windows 10 and Windows Server 2016
@@ -554,11 +554,7 @@ Services to securely store your Docker images.
 * [Container solutions](http://container-solutions.com/blog/)
 * [Container42](http://container42.com/)
 * [Cloud Native Landscape](https://github.com/cncf/landscape)
-* [Docker Cheat Sheet](http://docker.jens-piegsa.com) by [@JensPiegsa][JensPiegsa] *(updated for Docker 1.13)*
-* [Docker Cheat Sheet](https://github.com/eon01/DockerCheatSheet) by [@eon01](https://github.com/eon01)
-* [Docker Cheat Sheet][docker-cheat-sheet] by [@wsargent][wsargent] __MUST SEE__
 * [Docker Kubernetes Lab Handbook](https://github.com/xiaopeng163/docker-k8s-lab)
-* [Docker Printable Refcard][docker-quick-ref] by [@dimonomid][dimonomid]
 * [Docker vs. VMs? Combining Both for Cloud Portability Nirvana](https://www.rightscale.com/blog/cloud-management-best-practices/docker-vs-vms-combining-both-cloud-portability-nirvana)
 * [Docker Weekly](https://blog.docker.com/docker-weekly-archives/) Huge resource
 * __[Valuable Docker Links](http://www.nkode.io/2014/08/24/valuable-docker-links.html)__ High quality articles about docker! __MUST SEE__
@@ -575,7 +571,6 @@ Services to securely store your Docker images.
 ## Good Tips
 
 * [50+ Docker related tips, tricks and tutorials](https://nickjanetakis.com/blog/tag/docker) by [@nickjanetakis][nickjanetakis]
-
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Docker Jumpstart](https://github.com/odewahn/docker-jumpstart/): a quick introduction
 * [Docker Toolbox](https://docs.docker.com/toolbox/overview/) - It's a **legacy desktop application** for quick setup and launch of a Docker environment on older Mac (10.10 and below) and Windows (8.1 and below) systems. On newer systems it's recommended to use the [Docker for Mac][docker-for-mac] or [Docker for Windows][docker-for-windows].
 * [Docker Training](https://training.docker.com/) - Includes a free self-paced hands-on tutorial (free registration required or sign-in with DockerHub ID)
-* [How to Whale](https://github.com/carolynvs/howtowhale) - Learn Docker in your web browser, no setup or installation required by [@carolynvs](https://github.com/carolynvs).
 * [Katacoda](https://www.katacoda.com/): Learn Docker using Interactive Browser-Based Labs
 * [Learn Docker](https://github.com/dwyl/learn-docker) Full environment set up, screenshots, step-by-step tutorial and more resources (video, articles, cheat sheets) by [@dwyl](https://github.com/dwyl)
 * [Play With Docker](http://training.play-with-docker.com/) - PWD is a great way to get started with Docker from beginner to advanced users. Docker runs directly in your browser.
@@ -576,25 +575,12 @@ Services to securely store your Docker images.
 ## Good Tips
 
 * [50+ Docker related tips, tricks and tutorials](https://nickjanetakis.com/blog/tag/docker) by [@nickjanetakis][nickjanetakis]
-* [10 Things Not To Forget Before Deploying Docker In Production](https://www.slideshare.net/rightscale/docker-meetup-40826948)
-* [24 random docker tips](https://csabapalfi.github.io/random-docker-tips/) by [@csabapalfi](https://github.com/csabapalfi)
-* [6 Million Ways To Log In Docker](https://www.slideshare.net/raychaser/6-million-ways-to-log-in-docker-nyc-docker-meetup-12172014) by [@raychaser](https://twitter.com/raychaser)
-* [A Simple Way to Dockerize Applications](http://jasonwilder.com/blog/2014/10/13/a-simple-way-to-dockerize-applications/) by [@jwilder][jwilder]
-* [Automated Nginx Reverse Proxy for Docker](http://jasonwilder.com/blog/2014/03/25/automated-nginx-reverse-proxy-for-docker/) by [@jwilder][jwilder]
-* [Building good docker images](http://jonathan.bergknoff.com/journal/building-good-docker-images) by [@jbergknoff](https://github.com/jbergknoff)
+
 * [Container Best Practices](http://docs.projectatomic.io/container-best-practices/) - Red Hat's Project Atomic created a Container Best Practices guide which applies to everything and is updated regurlary.
 * [Dealing with linked containers dependency in docker-compose](http://brunorocha.org/python/dealing-with-linked-containers-dependency-in-docker-compose.html) by [@rochacbruno](https://github.com/rochacbruno)
-* [Docker CIFS – How to Mount CIFS as a Docker Volume](https://backdrift.org/docker-cifs-howto-mount-cifs-volume-docker-container)
-* [Docker Tips](http://www.mervine.net/notes/docker-tips) by [@jmervine](https://github.com/jmervine)
 * [Don't Repeat Yourself with Anchors, Aliases and Extensions in Docker Compose Files](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd) by [@King Chung Huang](https://github.com/kinghuang)
 * [GUI Apps with Docker](http://fabiorehm.com/blog/2014/09/11/running-gui-apps-with-docker/) by [@fgrehm][fgrehm]
-* [Migration from VMs to Containers](https://blog.jelastic.com/2016/10/11/migration-from-vms-to-containers/) - Decomposition of legacy Java EE applications using containers
-* [Nginx Proxy for Docker](https://blog.danivovich.com/2015/07/09/nginx-proxy-for-docker-containers/) (written 9 JUL 2015)
-* [Production Meteor and Node Using Docker, Part I](https://projectricochet.com/blog/production-meteor-and-node-using-docker-part-i) by [@projectricochet](https://github.com/projectricochet)
-* [Pulling Git into a Docker image without leaving SSH keys behind](http://blog.cloud66.com/pulling-git-into-a-docker-image-without-leaving-ssh-keys-behind/) by [@khash](https://github.com/khash)
-* [Resource Management in Docker](https://goldmann.pl/blog/2014/09/11/resource-management-in-docker/) by [@marekgoldmann](https://twitter.com/marekgoldmann)
-* [Running Production Hadoop Clusters in Docker Containers](https://conferences.oreilly.com/strata/big-data-conference-ca-2015/public/schedule/detail/38521)
-* [Using NSEnter with Boot2Docker](https://ro14nd.de/NSEnter-with-Boot2Docker)
+
 
 ## Raspberry Pi & ARM
 


### PR DESCRIPTION

* consolidate cheatsheets
* consolidate blogs
* remove articles about tools already included
* remove presentations 
* remove overly specific tutorials on node, java, CIFS
* remove How to whale as it is no longer working
* remove obsolete NSEnter article
* remove articles listed in nkode's valuable docker links and/or submitted via https://github.com/nkratzke/nkratzke.github.io/pull/1

