### PR TITLE
Add scuba to list of CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Docker EE is on the same code base as Docker CE, so also built from Moby, with c
 * [Powerline-Docker](https://github.com/adrianmo/powerline-docker) - A Powerline segment for showing the status of Docker containers by [@adrianmo](https://github.com/adrianmo)
 * [reg](https://github.com/jessfraz/reg) - Docker registry v2 command line client by [@jessfraz][jessfraz]
 * [sen](https://github.com/TomasTomecek/sen) - Terminal user interface for docker engine, by [@TomasTomecek](https://github.com/TomasTomecek)
+* [scuba](https://github.com/JonathonReinhart/scuba) - Transparently use Docker containers to encapsulate software build environments, by [@JonathonReinhart](https://github.com/JonathonReinhart)
 * [wharfee](https://github.com/j-bennet/wharfee) - Autocompletion and syntax highlighting for Docker commands. by [@j-bennet](https://github.com/j-bennet)
 * [tsaotun](https://github.com/qazbnm456/tsaotun) - Python based Assistance for Docker by [@qazbnm456](https://github.com/qazbnm456)
 


### PR DESCRIPTION
[Scuba](https://github.com/JonathonReinhart/scuba) is a tool I wrote which makes it easy to encapsulate build environments with Docker, and simplify the commands needed to e.g. `make`.  Complex projects often need a specific set of compiler/linker tools, libraries, etc. and tools like [GitLab CI](https://about.gitlab.com/features/gitlab-ci-cd/) recognize this, allowing you to specify your own Docker image in which a codebase should be built.

The problem is, using these same Docker containers in local command-line builds can be difficult. Scuba turns this:
```
$ docker run -it --rm -v $(pwd):/build:z -w /build -u $(id -u):$(id -g) gcc:5.1 make myprogram
```
into this:
```
$ scuba make
```
By including a simple `.scuba.yml` in your source code (under version control), you can concretely specify the build environment required for building the software.