### PR TITLE
update »Europa« organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Services to securely store your Docker images.
 * [Docket](https://github.com/netvarun/docket) - Custom docker registry that allows for lightning fast deploys through bittorrent by [@netvarun](https://github.com/netvarun/)
 * [Docker Hub](https://hub.docker.com/) provided by Docker Inc.
 * [Docker Registry v2][distribution] - The Docker toolset to pack, ship, store, and deliver content
-* [Europa :heavy_dollar_sign:](https://github.com/Distelli/europa) - Private docker registry with support for image pipelines and  webhooks. By [@Distelli](https://github.com/Distelli)
+* [Europa :heavy_dollar_sign:](https://github.com/puppetlabs/europa) - Private docker registry with support for image pipelines and webhooks. By [@puppetlabs](https://github.com/puppetlabs)
 * [GCE Container Registry](https://cloud.google.com/container-registry/) Fast, private Docker image storage on Google Cloud Platform
 * [GitLab Container Registry](https://docs.gitlab.com/ce/user/project/container_registry.html) - Repositories focused on using it images in GitLab CI
 * [Private Docker Registry :heavy_dollar_sign:](https://private-docker-registry.com) - Dedicated Conainer Registry Service with unlimited private repositories, users, teams, namespaces together with enterprise grade authentication LDAP/AD/OAuth/SAML.


### PR DESCRIPTION
Due to acquiring of Distelli by Puppet [1] the organization changed of
GitHub too.

Fixes [TravisCI#1270].

[1] https://puppet.com/blog/welcome-distelli-to-puppet-family
[TravicCI#1270] https://travis-ci.org/veggiemonk/awesome-docker/builds/319122631