### PR TITLE
remove retired project »shipyard«

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,6 @@ Native desktop applications for managing and montoring docker hosts and clusters
 - [Portus](https://github.com/SUSE/Portus) - Authorization service and frontend for Docker registry (v2) by [@SUSE](https://github.com/SUSE)
 - [Rapid Dashboard](https://github.com/ozlerhakan/rapid) - A simple query dashboard to use Docker Remote API by [@ozlerhakan](https://github.com/ozlerhakan/)
 - [Seagull](https://github.com/tobegit3hub/seagull) - Friendly Web UI to monitor docker daemon. by [@tobegit3hub](https://github.com/tobegit3hub)
-- [Shipyard](https://github.com/shipyard/shipyard) :skull: - Shipyard enables multi-host, Docker cluster management using Docker Swarm.
 - [Swirl](https://github.com/cuigh/swirl) - Swirl is a web management tool for Docker, focused on swarm cluster By [@cuigh](https://github.com/cuigh/)
 
 ## Docker Images


### PR DESCRIPTION
Beside of the projects `README.md`, it's website [1] is no longer
accessible.

> Shipyard Project
>
> After a long time I have decided to retire this project. It formed the
> foundation for what became Docker Universal Control Plane and I no
> longer have time to manage this. I asked for new maintainers but there
> seemed to be no interest.
>
> I want to thank all of the contributors for all of your help. Thank you.
>
> I will keep this repository open for a while to keep the source
> accessible for anyone that wants it.
>
> If you are looking for alternatives, here are a few open source Docker
> management applications available:
>
>    Rancher
>    Docker UI
>    Portainer
>
> Thank you.

[1] http://shipyard-project.com/