### PR TITLE
fix website link to Open Shift »Dedicated«

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ Services to securely store your Docker images.
 - [Hyper_](https://hyper.sh/) - Secure container hosting service with "nano-containers" and per-second billing.
 - [IBM Bluemix Container Service](https://console.bluemix.net/docs/containers/container_index.html) - Run Docker containers in a hosted cloud environment on IBM Bluemix.
 - [Jelastic Cloud](https://jelastic.cloud/) - "Easy-to-use" container hosting platfrom with automatic vertical and horizontal scaling. Available over 50+ hosting providers worldwide.
-- [OpenShift Dedicated](https://www.openshift.com/dedicated/index.html) - A hosted [OpenShift][openshift] cluster for running your Docker containers managed by Red Hat.
+- [OpenShift Dedicated](https://www.openshift.com/products/dedicated/) - A hosted [OpenShift][openshift] cluster for running your Docker containers managed by Red Hat.
 - [Sloppy.io](https://sloppy.io/) - all-in-one solution for container deployment and hosting – made and hosted in Germany
 - [Triton](https://www.joyent.com/) - Elastic container-native infrastructure by Joyent.
 


### PR DESCRIPTION
TravisCI Build #1500 [1] fails with HTTP 301 on Open Shift »Dedicated«
website link.

[1] https://travis-ci.org/veggiemonk/awesome-docker/builds/375524847