### PR TITLE
Add NVIDIA Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Tools and applications that are either installed inside containers or designed t
 - [GoSu](https://github.com/tianon/gosu) - Run this specific application as this specific user and get out of the pipeline (entrypoint script tool) by [@tianon](https://github.com/tianon)
 - [is-docker](https://github.com/sindresorhus/is-docker) - Check if the process is running inside a Docker container by [@sindresorhus][sindresorhus]
 - [lstags](https://github.com/ivanilves/lstags) - sync Docker images across registries by [@ivanilves](https://github.com/ivanilves)
+- [NVIDIA-Docker](https://github.com/NVIDIA/nvidia-docker) - The NVIDIA Container Runtime for Docker by [@NVIDIA](https://github.com/NVIDIA)
 - [supercronic](https://github.com/aptible/supercronic) - crontab-compatible job runner, designed specifically to run in containers by [@aptible](https://github.com/aptible/)
 - [TrivialRC](https://github.com/vorakl/TrivialRC) - A minimalistic Runtime Configuration system and process manager for containers [@vorakl](https://github.com/vorakl)
 


### PR DESCRIPTION
**https://github.com/NVIDIA/nvidia-docker**

**The NVIDIA Runtime for Docker, allows to build applications to run on CUDA with minimal driver setup on the host**

Note the CONTRIBUTING should be listed in the README, so it is easy to find out before the "Create pull request" button


