### PR TITLE
Fix build: whitelist cycle.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ before_script:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --white-list edit/master,sindresorhus/awesome,www.udacity.com,screwdriver.cd,veggiemonk/awesome-docker,vimeo.com
+  - awesome_bot README.md --white-list edit/master,sindresorhus/awesome,www.udacity.com,screwdriver.cd,veggiemonk/awesome-docker,vimeo.com,cycle.io
   - TOKEN=$GITHUB_TOKEN node buildMetadata.js && ./push.sh


### PR DESCRIPTION
Cycle.io returns 403 in travis and throws an error. 
Whitelisting it fixes travis

