### PR TITLE
Added docker-java-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Services to securely store your Docker images.
 - [Docker Client TypeScript](https://gitlab.com/masaeedu/docker-client) - Docker API client for JavaScript, automatically generated from Swagger API definition from moby repository. By [@masaeedu](https://github.com/masaeedu)
 - [docker-client](https://github.com/spotify/docker-client) - Java client for the Docker remote API. By [@spotify][spotify]
 - [docker-it-scala](https://github.com/whisklabs/docker-it-scala) - Docker integration testing kit with Scala by [@whisklabs](https://github.com/whisklabs)
+- [docker-java-api](https://github.com/amihaiemil/docker-java-api) - Lightweight, truly object-oriented, Java client for Docker's API. By [@amihaiemil](https://www.github.com/amihaiemil)
 - [docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin) - A Maven plugin for running and creating Docker images by [@fabric8io](https://github.com/fabric8io)
 - [Docker-PowerShell](https://github.com/Microsoft/Docker-PowerShell) - PowerShell Module for Docker
 - [Docker.DotNet](https://github.com/Microsoft/Docker.DotNet) - C#/.NET HTTP client for the Docker remote API by [@ahmetalpbalkan](ahmetalpbalkan)


### PR DESCRIPTION
Added this library: https://github.com/amihaiemil/docker-java-api

I think it's worth to be listed because it has a completely different approach than the other Java clients that are available on the market:
  * it is lightweight (only 2 transitive dependencies, both optional in some cases)
  * it can communicate with both a local Docker (via Unix sockets) as well as a remote one.
  * it is 100% encapsulated (it's an API, not an SDK)
  * it is extensible since everything happens via interfaces -- only 2 public entry points and from there the user works only with Java interfaces which they can decorate. 
  * any version of Docker's API can be used, either trough interfaces or by using the ``HttpClient`` directly, since we do not provide animating models, only JsonObjects.
  * high test coverage and strict quality control (see how we use [Rultor](http://www.rultor.com) in order to keep the master branch read-only,
  * innovative project management via [Zerocracy](https://www.zerocracy.com).

You can also read the [motivational blog post](https://www.amihaiemil.com/2018/03/10/java-api-for-docker.html).
