### PR TITLE
add container-web-tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Native desktop applications for managing and montoring docker hosts and clusters
 
 #### Web
 
+- [Container Web TTY](https://github.com/wrfly/container-web-tty) - Connect your containers via a web-tty [@wrfly](https://github.com/wrfly)
 - [Docker Compose UI](https://github.com/francescou/docker-compose-ui) - Manage docker-compose via HTTP. docker-compose-ui runs in a Docker container, mounts the hosts docker socket and exposes a RESTful API and AngularJS GUI
 - [Docker Registry Browser](https://github.com/klausmeyer/docker-registry-browser) - Web Interface for the Docker Registry HTTP API v2 by [@klausmeyer](https://github.com/klausmeyer)
 - [Docker Registry UI](https://github.com/atcol/docker-registry-ui) - A web UI for easy private/local Docker Registry integration by [@atcol](https://github.com/atcol)


### PR DESCRIPTION
It can help you get inside the container and execute commands via a web-tty.

Some features:

- exec into the container (ofcause)
- tail logs
- start/restart/stop the container
- audit exec logs
- kubernetes support
- remote exec via gRPC
- remote auth
- realtime sharing
- ...

Run with four lines:

```bash
docker run --rm -ti --name web-tty \
    -p 8080:8080 \
    -v /var/run/docker.sock:/var/run/docker.sock \
    wrfly/container-web-tty
```