### PR TITLE
Adds docker-image-size-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Examples by:
 
 ### Linter
 
+- [docker-image-size-limit](https://github.com/wemake-services/docker-image-size-limit) - A tool to keep an eye on your docker images size.
 - [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint) - A rule-based 'linter' for Dockerfiles by [@projectatomic](https://github.com/projectatomic)
 - [Dockerfilelint](https://github.com/replicatedhq/dockerfilelint) - A node module that analyzes a Dockerfile and looks for common traps, mistakes and helps enforce best practices by [@replicatedhq](https://github.com/replicatedhq)
 - [dockfmt](https://github.com/jessfraz/dockfmt) :construction: - Dockerfile formatter and parser by [@jessfraz][jessfraz]


### PR DESCRIPTION
`docker-image-size-limit` helps you solve just one problem: fail your CI if your image is growing too big.

It was an early morning, I was drinking my cup of tea and reviewing a PR from another programmer. It all looked good, just several new dependencies. So, I have decided to merge it. Problem is solved.

And then I realised that our image size is increased from ~250MiB to ~1.5GiB. That's insane! So, I have wrote a simple script to catch theses cases in the future.