### PR TITLE
Added Yacht to web Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Native desktop applications for managing and montoring docker hosts and clusters
 - [Swarmpit](https://github.com/swarmpit/swarmpit) - Swarmpit provides simple and easy to use interface for your Docker Swarm cluster. You can manage your stacks, services, secrets, volumes, networks etc.
 - [Swirl](https://github.com/cuigh/swirl) - Swirl is a web management tool for Docker, focused on swarm cluster By [@cuigh](https://github.com/cuigh/)
 - [Theia](https://github.com/eclipse-theia/theia) - Extensible platform to develop full-fledged multi-language Cloud & Desktop IDE-like products with state-of-the-art web technologies.
+- [Yacht (alpha)](https://github.com/SelfhostedPro/Yacht) - A Web UI for docker that focuses on templates and ease of use in order to make deployments as easy as possible.
 
 ## Docker Images
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Native desktop applications for managing and montoring docker hosts and clusters
 - [Swarmpit](https://github.com/swarmpit/swarmpit) - Swarmpit provides simple and easy to use interface for your Docker Swarm cluster. You can manage your stacks, services, secrets, volumes, networks etc.
 - [Swirl](https://github.com/cuigh/swirl) - Swirl is a web management tool for Docker, focused on swarm cluster By [@cuigh](https://github.com/cuigh/)
 - [Theia](https://github.com/eclipse-theia/theia) - Extensible platform to develop full-fledged multi-language Cloud & Desktop IDE-like products with state-of-the-art web technologies.
-- [Yacht (alpha)](https://github.com/SelfhostedPro/Yacht) - A Web UI for docker that focuses on templates and ease of use in order to make deployments as easy as possible.
+- [Yacht](https://github.com/SelfhostedPro/Yacht) :construction: - A Web UI for docker that focuses on templates and ease of use in order to make deployments as easy as possible. By [@SelfhostedPro](https://github.com/SelfhostedPro)
 
 ## Docker Images
 


### PR DESCRIPTION
Yacht is a web interface for managing docker containers with an emphasis on templating to make deployments as easy as possible. Think of it like a decentralized app store for servers that anyone can make packages for.
