### PR TITLE
Add cli template engine "dcinja" tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Native desktop applications for managing and montoring docker hosts and clusters
 ##### CLI tools
 
 - [captain](https://github.com/jenssegers/captain) - Easily start and stop docker compose projects from any directory. By [@jenssegers](https://github.com/jenssegers)
+- [dcinja](https://github.com/Falldog/dcinja) - The powerful and smallest binary size of template engine for docker command line environment. By [@Falldog](https://github.com/Falldog)
 - [docker-ls](https://github.com/mayflower/docker-ls) - CLI tools for browsing and manipulating docker registries by [@mayflower](https://github.com/mayflower)
 - [docker pushrm](https://github.com/christian-korneck/docker-pushrm) - A Docker CLI plugin that lets you push the README.md file from the current directory to Docker Hub. Also supports Quay and Harbor. By [@christian-korneck](https://github.com/christian-korneck)
 - [dockersql](https://github.com/crosbymichael/dockersql) - A command line interface to query Docker using SQL by [@crosbymichael](https://github.com/crosbymichael)


### PR DESCRIPTION
Add cli template engine `dcinja` tutorial in README.
The powerful and smallest binary size of template engine for docker command line environment.