### PR TITLE
Add Docker + cloud-init Terraform module to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ Services to securely store your Docker images.
 - [Shutit](https://github.com/ianmiell/shutit) - Tool for building and maintaining complex Docker deployments by [@ianmiell](https://github.com/ianmiell)
 - [subuser](https://github.com/subuser-security/subuser) - Makes it easy to securely and portably run graphical desktop applications in Docker
 - [T.A.D.S. boilerplate](https://github.com/Thomvaill/tads-boilerplate) - The power of Ansible and Terraform + the simplicity of Docker Swarm = Infrastructure as Code and DevOps best practices. By [@Thomvaill](https://github.com/Thomvaill)
+- [Terraform cloud-init config](https://github.com/christippett/terraform-cloudinit-container-server) - Terraform module for deploying a single Docker image or `docker-compose.yaml` file to any Cloud™ VM
 - [Turbo](https://github.com/ramitsurana/turbo) - Simple and Powerful utility for docker. By [@ramitsurana][ramitsurana]
 - [udocker](https://github.com/indigo-dc/udocker) - A tool to execute simple docker containers in batch or interactive systems without root privileges by [@inidigo-dc](https://github.com/indigo-dc)
 - [Vagrant - Docker provider](https://www.vagrantup.com/docs/providers/docker/basics) - Good starting point is [vagrant-docker-example](https://github.com/bubenkoff/vagrant-docker-example) by [@bubenkoff](https://github.com/bubenkoff)


### PR DESCRIPTION
I really appreciate the attention that went into writing the contribution guidelines. Takes the guesswork out of what to expect from a PR 🙂

I'd like to contribute a link to a Terraform module I've recently created that bootstraps a VM with Docker + its associated config using `cloud-init`. The config it generates can be used with any of the major cloud platforms (thanks to `cloud-init`) and includes some useful extras like Traefik for automating the provision of SSL certificates through Let's Encrypt.

Unfortunately it doesn't really lend itself to a snappy title. I'd welcome any feedback you have!