### PR TITLE
Mark Boot2Docker as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Services to securely store your Docker images.
 
 - [batect](https://github.com/batect/batect) - build and testing environments as code tool: Dockerised build and testing environments made easy by [@charleskorn](https://github.com/charleskorn)
 - [Binci](https://github.com/binci/binci) - Containerize your development workflow. (formerly DevLab by [@TechnologyAdvice](https://github.com/TechnologyAdvice))
-- [Boot2Docker](https://github.com/boot2docker/boot2docker) - Docker for OSX and Windows
+- [Boot2Docker](https://github.com/boot2docker/boot2docker) :skull: - Docker for OSX and Windows
 - [construi](https://github.com/lstephen/construi) - Run your builds inside a Docker defined environment by [@lstephen](https://github.com/lstephen)
 - [Crashcart](https://github.com/oracle/crashcart) - Sideload Linux binaries into a running container for troubleshooting by [@Oracle][oracle]
 - [dde](https://github.com/whatwedo/dde) :construction: - Local development environment toolset based on Docker. By [@whatwedo](https://github.com/whatwedo)


### PR DESCRIPTION
Boot2Docker is deprecated and unmaintained, the repository has been archived. This PR reflects this by adding the corresponding symbol to the Boot2Docker entry.
