### PR TITLE
feat(community): add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,6 +822,10 @@ Services to securely store your Docker images.
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/veggiemonk/awesome-docker.svg)](https://starchart.cc/veggiemonk/awesome-docker)
+
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=veggiemonk/awesome-docker)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=veggiemonk/awesome-docker)
  
 
 [contributing]: https://github.com/veggiemonk/awesome-docker/blob/master/.github/CONTRIBUTING.md


### PR DESCRIPTION
Hi community!

We're the maintainers of [Apache APISIX](https://github.com/apache/apisix). To better present how our community grows, we develop a tool to show contributors growing history on https://github.com/api7/contributor-graph. Since we found it helpful, we think maybe if it could help other communities. It has also already been deployed in [Skywalking](https://skywalking.apache.org/team/#contributor-over-time), [DolphinScheduler](https://github.com/apache/dolphinscheduler#contributor-over-time), [Openwhisk](https://openwhisk.apache.org/community.html), [Pingcap-doc](https://github.com/pingcap/docs-dm) and some other OSS repos.

### WHAT IT IS

![image](https://user-images.githubusercontent.com/34589752/119575525-30aee380-bd85-11eb-8835-4a8cb3193400.png)

Basically, it just shows the contributors growth over time. All of the procedures are running on GCP, and it would automatically update the graph each day, so the link would always present the real-time data, just like starcc. There is some other stuff to [play around](https://www.apiseven.com/en/contributor-graph) with if you would like to give it a try~

### HOW IT WORKS

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each contributor.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻 
