### PR TITLE
Add 'RAUDI' (Regulary and Automatically Updated Docker Images)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker)
 - [percheron](https://github.com/ashmckenzie/percheron) :skull: - Organise your Docker containers with muscle and intelligence by [@ashmckenzie](https://github.com/ashmckenzie)
 - [plash](https://github.com/ihucos/plash) - A container run and build engine - runs inside docker.
 - [podman-compose](https://github.com/containers/podman-compose) - a script to run docker-compose.yml using podman by [@containers][containers]
+- [RAUDI](https://github.com/cybersecsi/RAUDI) - A tool to automatically update (and optionally push to Docker Hub) Docker Images for 3rd party software whenever theres is a new release/update/commit. By [@SecSI](https://github.com/cybersecsi) 
 - [rocker-compose](https://github.com/grammarly/rocker-compose) :skull: - Docker composition tool with idempotency features for deploying apps composed of multiple containers. By[@grammarly](grammarly).
 - [rocker](https://github.com/grammarly/rocker) :skull: - Extended Dockerfile builder. Supports multiple FROMs, MOUNTS, templates, etc. by [@grammarly](grammarly).
 - [Smalte](https://github.com/roquie/smalte) – Dynamically configure applications that require static configuration in docker container. By [@roquie](https://github.com/roquie)


### PR DESCRIPTION
[RAUDI](https://github.com/cybersecsi/RAUDI) is a tool that allows to automatically and regularly (through GitHub Actions) update Docker Images for 3rd party software that does not have an official Docker Image on the Docker Hub. Every day (at midnight) it checks if there is a new release/commit and if so it build a new image and pushes it to the Docker Hub. 
Of course it can also be forked for personal usage or used locally (for using it regularly you may set a cron job, for example).
