### PR TITLE
Add 'RAUDI'

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Applications designed to help or simplify building **new** images
 - [packer](https://www.packer.io/docs/builders/docker) - Hashicorp tool to build machine images including docker image integrated with configuration management tools like chef, puppet, ansible
 - [portainer](https://github.com/duedil-ltd/portainer) - Apache Mesos framework for building Docker images by [@duedil-ltd](https://github.com/duedil-ltd)
 - [Production-Ready Python Containers :heavy_dollar_sign:](https://pythonspeed.com/products/pythoncontainer/) - A template for creating production-ready Docker images for Python applications.
+- [RAUDI](https://github.com/cybersecsi/RAUDI) - A tool to automatically update (and optionally push to Docker Hub) Docker Images for 3rd party software whenever theres is a new release/update/commit. By [@SecSI](https://github.com/cybersecsi) 
 - [runlike](https://github.com/lavie/runlike) - Generate `docker run`command and options from running containers by [@lavie](https://github.com/lavie)
 - [SkinnyWhale](https://github.com/djosephsen/skinnywhale) :skull: - Skinnywhale helps you make smaller (as in megabytes) Docker containers.
 - [Smith](https://github.com/oracle/smith) - A Micocontainer Builder and can perform multi-stage builds after the image is built [Oracle][oracle]


### PR DESCRIPTION
[RAUDI](https://github.com/cybersecsi/RAUDI) is a tool that allows to automatically and regularly (through GitHub Actions) update Docker Images for 3rd party software that does not have an official Docker Image on the Docker Hub. Every day (at midnight) it checks if there is a new release/commit and if so it build a new image and pushes it to the Docker Hub. 
Of course it can also be forked for personal usage or used locally (for using it regularly you may set a cron job, for example).

I already did a PR (#969) but as you made me understand the *Projects > Builder* is a more fit section. 