### PR TITLE
Add Stevedore

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Native desktop applications for managing and montoring docker hosts and clusters
 - [DockStation](https://github.com/DockStation/dockstation) - A developer centric UI to configure, monitor, and manage services and containers [@dock_station](https://twitter.com/dock_station)
 - [Lifeboat](https://github.com/jplhomer/lifeboat) - An easy way to launch Docker projects with a graphical interface on your Mac. [@jplhomer](https://github.com/jplhomer)
 - [Simple Docker UI](https://github.com/felixgborrego/simple-docker-ui) - built on Electron. By [@felixgborrego](https://github.com/felixgborrego/)
+- [Stevedore](https://github.com/slonopotamus/stevedore) - Good Docker Desktop replacement for Windows. Both Linux and Windows Containers are supported. [@slonopotamus](https://github.com/slonopotamus)
 
 #### Terminal
 


### PR DESCRIPTION
This project aims to provide a frictionless Docker experience on Windows.

Stevedore can be used as a replacement for Docker Desktop, DockerMsftProvider or Mirantis Container Runtime.
