### PR TITLE
Add Ilum

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 -   [Flynn](https://github.com/flynn/flynn) :skull: - A next generation open source platform as a service
 -   [Hephy Workflow](https://github.com/teamhephy/workflow) - Open source PaaS for Kubernetes that adds a developer-friendly layer to any Kubernetes cluster, making it easy to deploy and manage applications. Fork of [Deis Workflow](https://github.com/deis/workflow)
 -   [Krane](https://github.com/krane/krane) - Toolset for managing container workloads on remote servers
+-   [Ilum](https://ilum.cloud/docs/) - Open data lakehouse for big data, AI, and analytics. Runs Spark on Kubernetes, YARN, or hybrid setups with Docker support and built-in SQL, BI, and open table formats like Delta, Iceberg, and Hudi.
 -   [Nanobox](https://github.com/nanobox-io/nanobox) :heavy_dollar_sign: - An application development platform that creates local environments that can then be deployed and scaled in the cloud.
 -   [OpenShift][openshift] - An open source PaaS built on [Kubernetes][kubernetes] and optimized for Dockerized app development and deployment by [Red Hat](https://www.redhat.com/en)
 -   [Tsuru](https://github.com/tsuru/tsuru) - Tsuru is an extensible and open source Platform as a Service software


### PR DESCRIPTION
Adding [Ilum](https://ilum.cloud/docs/), which is a data Lakehouse which can be started within a docker container. It's better to be used within K8s env because of its modules like Apache Airflow, MLFlow, Superset etc. but using pure docker or docker-compose is also fine.