### PR TITLE
fix: update actions to latest available version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,12 +11,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4.2.2
-      - uses: actions/setup-node@4.3.0
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.3.0
         with:
           node-version: lts/*
 
-      - uses: actions/cache@4.2.3
+      - uses: actions/cache@v4.2.3
         id: cache
         with:
           path: ~/.npm

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,12 +11,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
-      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
+      - uses: actions/checkout@4.2.2
+      - uses: actions/setup-node@4.3.0
         with:
           node-version: lts/*
 
-      - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+      - uses: actions/cache@4.2.3
         id: cache
         with:
           path: ~/.npm


### PR DESCRIPTION
Fixes incompatibility with used action/cache version, see https://github.com/veggiemonk/awesome-docker/actions.

They're immutable tags anyways, not really a need to use sha's here, but we still can to prevent supply chain attacks from Github itself.
Happy to hear your feedback!