### PR TITLE
Add av/harbor to Container Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 -   [draw-compose](https://github.com/Alexis-benoist/draw-compose) :skull: - Utility to draw a schema of a docker compose by [@Alexis-benoist](https://github.com/Alexis-benoist)
 -   [elsy](https://github.com/cisco/elsy) - An opinionated, multi-language, build tool based on Docker and Docker Compose
 -   [habitus](https://github.com/cloud66-oss/habitus) - A Build Flow Tool for Docker by [@cloud66](https://github.com/cloud66)
--   [LLM Harbor](https://github.com/av/harbor) - A CLI and companion app to effortlessly run LLM backends, APIs, frontends, and services with one command.
 -   [kompose](https://github.com/kubernetes/kompose) - Go from Docker Compose to Kubernetes
+-   [LLM Harbor](https://github.com/av/harbor) - A CLI and companion app to effortlessly run LLM backends, APIs, frontends, and services with one command. By [@av](https://github.com/av)
 -   [Maestro](https://github.com/toscanini/maestro) :skull: - Maestro provides the ability to easily launch, orchestrate and manage multiple Docker containers as single unit by [@tascanini](https://github.com/toscanini)
 -   [percheron](https://github.com/ashmckenzie/percheron) :skull: - Organise your Docker containers with muscle and intelligence by [@ashmckenzie](https://github.com/ashmckenzie)
 -   [plash](https://github.com/ihucos/plash) - A container run and build engine - runs inside docker.


### PR DESCRIPTION
av/harbor is a dockerized LLM toolkit to start using 90+ preconfigured LLM-related projects with minimal effort. It includes a CLI and a companion desktop app, and tailored for self-host/homelab use cases. The project wraps Docker CLI with extra convenience options such as: default services, config profiles (including imports from a URL), tunnels, local/remote address and more.