### PR TITLE
Add DockMate to Terminal UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Native desktop applications for managing and monitoring docker hosts and cluster
 -   [dockdash](https://github.com/byrnedo/dockdash) detailed stats. By [@byrnedo]
 -   [Docker-mon](https://github.com/icecrime/docker-mon) :skull: - Console-based Docker monitoring by [@icecrime](https://github.com/icecrime)
 -   [dockly](https://github.com/lirantal/dockly) - An interactive shell UI for managing Docker containers by [@lirantal](https://github.com/lirantal)
+-   [DockMate](https://github.com/shubh-io/dockmate) - Lightweight terminal-based Docker and Podman manager with a text-based user interface, by [@shubh-io](https://github.com/shubh-io).
 -   [DockSTARTer](https://github.com/GhostWriters/DockSTARTer) - DockSTARTer helps you get started with home server apps running in Docker by [GhostWriters](https://github.com/GhostWriters)
 -   [docui](https://github.com/skanehira/docui) - :skull: An interactive shell UI for managing Docker containers. Also works in Windows. By [@skanehira]
 -   [dry](https://github.com/moncho/dry) - An interactive CLI for Docker containers by [@moncho](https://github.com/moncho)


### PR DESCRIPTION
Adds DockMate, a terminal-based Docker and Podman TUI manager, to the Terminal UI section.
