### PR TITLE
Add mesh-router (nsl.sh) to Networking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 -   [fabio](https://github.com/fabiolb/fabio) - A fast, modern, zero-conf load balancing HTTP(S) router for deploying microservices managed by consul. By [@magiconair](https://github.com/magiconair) (Frank Schroeder)
 -   [h2o-proxy](https://github.com/zchee/h2o-proxy) :skull: - Automated H2O reverse proxy for Docker containers. An alternative to [jwilder/nginx-proxy][nginxproxy] by [@zchee](https://github.com/zchee)
 -   [Let's Encrypt Nginx-proxy Companion](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion) - A lightweight companion container for the nginx-proxy. It allow the creation/renewal of Let's Encrypt certificates automatically. By [@JrCs](https://github.com/JrCs)
+-   [mesh-router](https://github.com/Yundera/mesh-router) - Free domain(nsl.sh) provider for Docker containers with automatic HTTPS routing. Uses Wireguard VPN to securely route subdomain requests across networks. Ideal for self-hosted NAS and cloud deployments. By [@Yundera](https://github.com/Yundera)
 -   [muguet](https://github.com/mattallty/muguet) :skull: - DNS Server & Reverse proxy for Docker environments. By [@mattallty](https://github.com/mattallty)
 -   [Nginx Proxy Manager](https://github.com/jc21/nginx-proxy-manager) - A beautiful web interface for proxying web based services with SSL. By [@jc21](https://github.com/jc21)
 -   [nginx-proxy][nginxproxy] - Automated nginx proxy for Docker containers using docker-gen by [@jwilder][jwilder]
@@ -295,7 +296,6 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 -   [Swarm Ingress Router](https://github.com/tpbowden/swarm-ingress-router) :skull: - Route DNS names to Swarm services based on labels. By [@tpbowden](https://github.com/tpbowden/)
 -   [Swarm Router](https://github.com/flavioaiello/swarm-router) - A «zero config» service name based router for docker swarm mode with a fresh and more secure approach. By [@flavioaiello](https://github.com/flavioaiello)
 -   [Træfɪk](https://github.com/containous/traefik) - Automated reverse proxy and load-balancer for Docker, Mesos, Consul, Etcd... By [@EmileVauge](https://github.com/emilevauge)
--   [nsl.sh](https://github.com/Yundera/mesh-router) - Free domain provider for Docker containers with automatic HTTPS routing. Uses Wireguard VPN to securely route subdomain requests across networks. Ideal for self-hosted NAS and cloud deployments. By [@Yundera](https://github.com/Yundera)
 
 ### Runtime
 


### PR DESCRIPTION
Add mesh-router (nsl.sh) to Networking section

mesh-router is the open-source routing system that powers nsl.sh, a free domain provider for Docker containers.

Features:
- Automatic HTTPS subdomain generation (e.g., app-user.nsl.sh)
- Wireguard VPN-secured routing across networks
- Provider/Requester architecture for distributed deployments
- Production-ready with active maintenance

The project includes:
- Installation examples (docker run & docker-compose)
- Usage examples for Provider and Requester modes
- Well-documented README with development guide
- MIT license

Entry added alphabetically in the Networking section.

Website: https://nsl.sh
Repository: https://github.com/Yundera/mesh-router