### PR TITLE
Add What Broke Today to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 - [Zabbix Docker module](https://github.com/monitoringartist/Zabbix-Docker-Monitoring) - Zabbix module that provides discovery of running containers, CPU/memory/blk IO/net container metrics. Systemd Docker and LXC execution driver is also supported. It's a dynamically linked shared object library, so its performance is (~10x) better, than any script solution.
 - [Zabbix Docker](https://github.com/gomex/docker-zabbix) - Monitor containers automatically using zabbix LLD feature.
 
+- [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator tracking 100+ cloud services with real-time Telegram alerts. Helps DevOps teams monitor third-party service dependencies.
 ### Networking
 
 -   [Calico][calico] - Calico is a pure layer 3 virtual network that allows containers over multiple docker-hosts to talk to each other.


### PR DESCRIPTION
## Summary
- Adds [What Broke Today](https://whatbroke.today) to the Monitoring section

## About What Broke Today
What Broke Today is an AI-powered outage aggregator that:
- Monitors 100+ cloud service status pages in real-time
- Uses AI to filter out maintenance/scheduled updates
- Sends instant alerts via Telegram
- Provides a clean web dashboard for browsing incidents

This tool helps DevOps teams stay informed about third-party service outages that may affect their Docker-based infrastructure.

## Checklist
- [x] Link is working
- [x] Description follows existing format
- [x] Placed in appropriate section (Monitoring)