### PR TITLE
Update BunkerWeb branding and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 
 ### Reverse Proxy
 
--   [bunkerized-nginx](https://github.com/bunkerity/bunkerized-nginx) - Web app hosting and reverse proxy secure by default. By [@bunkerity](https://github.com/bunkerity)
+-   [BunkerWeb](https://github.com/bunkerity/bunkerweb) - Open-source and next-gen Web Application Firewall (WAF). By [Bunkerity](https://www.bunkerity.com)
 -   [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) - Caddy-based reverse proxy, configured with service or container labels. By [@lucaslorentz](https://github.com/lucaslorentz)
 -   [caddy-docker-upstreams](https://github.com/invzhi/caddy-docker-upstreams) - Docker upstreams module for Caddy, configured with container labels. By [@invzhi](https://github.com/invzhi)
 -   [Docker Dnsmasq Updater](https://github.com/moonbuggy/docker-dnsmasq-updater) - Update a remote dnsmasq server with Docker container hostnames.


### PR DESCRIPTION
## Description
This PR updates the entry for `bunkerized-nginx` to reflect its new name, `BunkerWeb`.
### Changes
- **Project Name**: Renamed `bunkerized-nginx` to `BunkerWeb`.
- **URL**: Updated repository URL to [https://github.com/bunkerity/bunkerweb](https://github.com/bunkerity/bunkerweb).
- **Description**: Updated to match current branding: "Open-source and next-gen Web Application Firewall (WAF)".
- **Author**: Updated author link to the official website [https://www.bunkerity.com](https://www.bunkerity.com).
## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] The link is valid and trustworthy.
- [x] The description is concise.
- [x] I have placed the link in the correct section (Reverse Proxy).