### PR TITLE
Add Drydock — container update monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ Services to securely store your Docker images.
 -   [Depot :heavy_dollar_sign:](https://depot.dev) - Build Docker images fast, in the cloud. Blazing fast compute, automatic intelligent caching, and zero configuration. [Done in seconds](https://depot.dev/#benchmarks).
 -   [Diun](https://github.com/crazy-max/diun) - Receive notifications when an image or repository is updated on a Docker registry by [@crazy-max].
 -   [dockcheck](https://github.com/mag37/dockcheck) - A script checking updates for docker images without pulling then auto-update selected/all containers. With notifications, pruning and more.
+-   [Drydock](https://github.com/CodesWhat/drydock) - Open-source container update monitoring with web dashboard, 15 registries, 16 notification triggers, and security scanning. Drop-in WUD replacement. By [@CodesWhat](https://github.com/CodesWhat)
 -   [Docker plugin for Jenkins](https://github.com/jenkinsci/docker-plugin/) - The aim of the docker plugin is to be able to use a docker host to dynamically provision a slave, run a single build, then tear-down that slave.
 -   [Drone](https://github.com/drone/drone) - Continuous integration server built on Docker and configured using YAML files.
 -   [Gantry](https://github.com/shizunge/gantry) - Automatically update selected Docker swarm services.


### PR DESCRIPTION
## Add Drydock

[Drydock](https://github.com/CodesWhat/drydock) is an open-source container update monitoring tool with a web dashboard, support for 15 registries, 16 notification triggers, security scanning (Trivy), and Prometheus metrics. It's a drop-in replacement for What's Up Docker (WUD).

### Checklist

- [x] Links to GitHub repository (not website)
- [x] Clear, concise description on one line
- [x] Alphabetically ordered (placed between `dockcheck` and `Docker plugin for Jenkins`)
- [x] Entry format matches existing entries
- [x] Project is actively maintained
- [x] I am the author/maintainer of this project