### PR TITLE
Add InfraScan: Advanced Infrastructure Auditor for AWS and IaC security

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 -   [docker-explorer](https://github.com/google/docker-explorer) - A tool to help forensicate offline docker acquisitions by [@Google][google]
 -   [docker-lock](https://github.com/safe-waters/docker-lock) - A cli-plugin for docker to automatically manage image digests by tracking them in a separate Lockfile. By [@safe-waters][safe-waters]
 -   [dvwassl](https://github.com/Peco602/dvwassl) - SSL-enabled Damn Vulnerable Web App to test Web Application Firewalls. By [@Peco602][peco602]
+-   [InfraScan](https://infrascan.soldevelo.com/) - Advanced Infrastructure Auditor providing comprehensive scans for AWS cost antipatterns, IaC security issues, and container vulnerabilities. By [SolDevelo](https://infrascan.soldevelo.com/)
 -   [KICS](https://github.com/checkmarx/kics) - an infrastructure-as-code scanning tool, find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle. Can be extended for additional policies. By [Checkmarx](https://github.com/Checkmarx)
 -   [notary](https://github.com/theupdateframework/notary) - a server and a client for running and interacting with trusted collections. By [@TUF](https://github.com/theupdateframework)
 -   [oscap-docker](https://github.com/OpenSCAP/openscap) - OpenSCAP provides oscap-docker tool which is used to scan Docker containers and images. By [OpenSCAP](https://github.com/OpenSCAP)


### PR DESCRIPTION
# TLDR
- [x] all entries sorted alphabetically (from A to Z),
- [x] clear and short description of the project
- [x] project MUST have: How to setup/install
- [x] project MUST have: How to use (examples)
## Description
This PR adds [InfraScan](https://infrascan.soldevelo.com/) to the **Security** category.
InfraScan is an Advanced Infrastructure Auditor developed by SolDevelo. It helps developers and engineering teams analyze infrastructure for AWS cost antipatterns, IaC security issues (such as Checkov and IAM policies), and container vulnerabilities. It doesn't require complex setups or cloud credentials for the initial scan.
I've ensured the entry is placed in alphabetical order within the Security section and followed the formatting guidelines (`[Name](link) - Description. By [Author](link)`) as requested in `CONTRIBUTING.md`.