### PR TITLE
Add ADRG to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 
 ### Monitoring
 
-- [ADRG](https://github.com/jaldertech/adrg) - Aldertech Dynamic Resource Governor. Monitors and dynamically enforces cgroups v2 limits based on thermal, memory, IO pressure and media streaming activity.
+- [ADRG](https://github.com/jaldertech/adrg) - Dynamic Docker resource governor using cgroups v2 to manage system load.
 - [Autoheal](https://github.com/willfarrell/docker-autoheal) - Monitor and restart unhealthy docker containers automatically.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [Checkmate](https://github.com/bluewave-labs/checkmate) - Checkmate is an open-source, self-hosted tool designed to track and monitor server hardware, uptime, response times, and incidents in real-time with beautiful visualizations.


### PR DESCRIPTION
Adding ADRG (Aldertech Dynamic Resource Governor) to the Monitoring section. It dynamically enforces cgroups v2 limits based on system pressure.