### PR TITLE
Add JARVIS - Self-hosted AI assistant platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Services to securely store your Docker images.
 -   [An Annotated Docker Config for Frontend Web Development](https://nystudio107.com/blog/an-annotated-docker-config-for-frontend-web-development) A local development environment with Docker allows you to shrink-wrap the devops your project needs as config, making onboarding frictionless.
 -   [Local Docker DB](https://github.com/alexmacarthur/local-docker-db) a list of docker-compose samples for a lot of databases by [alexmacarthur](https://github.com/alexmacarthur)
 -   [Webstack-micro](https://github.com/ferbs/webstack-micro) Demo web app showing how Docker Compose might be used to set up an API Gateway, centralized authentication, background workers, and WebSockets as containerized services.
+-   [JARVIS](https://github.com/hyhmrright/JARVIS) - Self-hosted AI assistant platform with complete Docker Compose orchestration (PostgreSQL, Redis, Qdrant, MinIO, backend, frontend). One-command deployment with RAG, multi-LLM support, and plugin SDK.
 
 ## Good Tips
 


### PR DESCRIPTION
I'm adding JARVIS to the Demos and Examples section.

JARVIS is an open-source, self-hosted AI assistant platform that demonstrates a production-grade Docker Compose setup:

- **Complete Docker Compose orchestration**: PostgreSQL, Redis, Qdrant (vector DB), MinIO (object storage), backend, and frontend — all in one `docker-compose.yml`
- **One-command deployment**: `docker compose up -d` brings up the full stack
- **Production features**: RAG knowledge base, multi-LLM support (DeepSeek/OpenAI/Anthropic), Plugin SDK, multi-channel gateway (Slack/Discord/Telegram), RBAC, and observability stack (Prometheus/Loki/Grafana)

Project: https://github.com/hyhmrright/JARVIS
License: MIT

Please let me know if this entry needs any adjustments.