### PR TITLE
Add API Status Check to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 
 ### Monitoring
 
+- [API Status Check](https://apistatuscheck.com) - Monitor and aggregate status pages and incident reports from 1,130+ APIs and SaaS services, including major container platforms and DevOps tools.
 - [Autoheal](https://github.com/willfarrell/docker-autoheal) - Monitor and restart unhealthy docker containers automatically.
 - [cAdvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers.
 - [Checkmate](https://github.com/bluewave-labs/checkmate) - Checkmate is an open-source, self-hosted tool designed to track and monitor server hardware, uptime, response times, and incidents in real-time with beautiful visualizations.


### PR DESCRIPTION
This PR adds **API Status Check** to the Monitoring section.

## What it does:

API Status Check aggregates status pages and incident reports from 1,130+ APIs and SaaS services, including:
- Container registries (Docker Hub, GitHub Container Registry, Google Container Registry)
- Orchestration platforms (Kubernetes, AWS ECS, Google Cloud Run)
- Cloud providers (AWS, GCP, Azure, DigitalOcean)
- CI/CD tools (GitHub Actions, CircleCI, GitLab)
- Monitoring tools (Datadog, New Relic, Sentry)

## Why it's useful for Docker users:

DevOps teams managing containerized apps need visibility into the entire infrastructure stack. When a deployment fails or monitoring goes down, API Status Check helps quickly determine if it's an external service issue (e.g., Docker Hub outage) vs. an internal problem.

## Placement:

Added alphabetically between Autoheal and cAdvisor to maintain the existing sort order.