### PR TITLE
Add releaserun-dockerfile-linter to Linting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Examples by:
 -   [vimagick](https://github.com/vimagick/dockerfiles)
 
 ### Linter
+- [releaserun-dockerfile-linter](https://github.com/Releaserun/releaserun-dockerfile-linter) - Free client-side Dockerfile security linter. 18 rules covering security, best practices, performance and maintainability. No server, no signup required.
 
 - [Dockadvisor](https://github.com/deckrun/dockadvisor) - Lightweight Dockerfile linter with 60+ rules, quality scoring, and security checks.
 - [Dockerfile Linter](https://releaserun.com/tools/dockerfile-linter/) - Free browser-based Dockerfile linter with security checks, best practice rules, and actionable fix suggestions. No install required.


### PR DESCRIPTION
## Summary

Adding [releaserun-dockerfile-linter](https://github.com/Releaserun/releaserun-dockerfile-linter) to the Linter section.

**What it does:** Free, client-side Dockerfile security linter with 18 rules across 4 categories (Security, Best Practices, Performance, Maintainability). Everything runs in the browser — the Dockerfile never leaves the user's device.

**Why it belongs here:**
- Docker-specific tool (lints Dockerfiles)
- Active GitHub repository with MIT license
- 18 rules covering real security issues (running as root, hardcoded secrets, using `latest` tag, etc.)
- Client-side only — no server dependency

Resubmitting after fixing the contributing guideline issue from the previous PR (was linking to a marketing page — now linking to the GitHub repository directly).