### PR TITLE
Add NORA - multi-protocol artifact registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ Services to securely store your Docker images.
 -   [Harbor](https://github.com/goharbor/harbor) An open source trusted cloud native registry project that stores, signs, and scans content. Supports replication, user management, access control and activity auditing. By [CNCF](https://www.cncf.io) formerly [VMWare][vmware]
 - [JFrog Artifactory :yen:](https://jfrog.com/artifactory/) - Artifact Repository Manager, can be used as private Docker Registry as well.
 - [Kraken](https://github.com/uber/kraken) - Uber's Highly scalable P2P docker registry, capable of distributing TBs of data in seconds.
-- [nscr](https://github.com/jhstatewide/nscr) - A light-weight, self-contained container registry that's easy to run and maintain.
 - [NORA](https://github.com/getnora-io/nora) - Lightweight multi-protocol artifact registry supporting Docker, Maven, npm, Cargo and PyPI in a single 32MB binary. Pull-through cache, Web UI, Prometheus metrics, RBAC auth.
+- [nscr](https://github.com/jhstatewide/nscr) - A light-weight, self-contained container registry that's easy to run and maintain.
 - [Quay.io :yen:](https://quay.io/) - Secure hosting for private Docker repositories.
 - [Registryo](https://github.com/inmagik/registryo) - UI and token based authentication server for onpremise docker registry.
 - [RepoFlow](https://www.repoflow.io) - A simple and easy-to-use package management platform with Docker support alongside other formats like PyPI, Maven, npm, and Helm. Includes smart search, built-in Docker image scanning, and a great free option for both self-hosted and cloud use.


### PR DESCRIPTION
NORA is a lightweight multi-protocol artifact registry built with Rust. Single 32MB binary supports Docker Registry v2, Maven, npm, Cargo, and PyPI with pull-through cache, Web UI, Prometheus metrics, and RBAC auth.

- GitHub: https://github.com/getnora-io/nora
- Docs: https://getnora.dev
- License: MIT