### PR TITLE
Add DockProbe - lightweight Docker monitoring with anomaly detection & Telegram alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 - [DLIA](https://github.com/zorak1103/dlia) - DLIA is an AI-powered Docker log monitoring agent that uses Large Language Models (LLMs) to intelligently analyze container logs, detect anomalies, and provide contextual insights over time. By [zorak1103](https://github.com/zorak1103).
 - [Docker-Alertd](https://github.com/deltaskelta/docker-alertd) :ice_cube: - Monitor and send alerts based on docker container resource usage/statistics.
 - [Docker-Flow-Monitor](https://github.com/docker-flow/docker-flow-monitor) :ice_cube: - Reconfigures Prometheus when a new service is updated or deployed automatically.
+- [DockProbe](https://github.com/deep-on/dockprobe) - Lightweight Docker monitoring dashboard in a single container. Real-time metrics, 6 anomaly detection rules, Telegram alerts, and 16 automated security scans. Zero config, ~50MB RAM. By [DeepOn](https://github.com/deep-on).
 - [DockProc](https://gitlab.com/n0r1sk/dockproc) - I/O monitoring for containers on processlevel.
 - [dockprom](https://github.com/stefanprodan/dockprom) - Docker hosts and containers monitoring with Prometheus, Grafana, cAdvisor, NodeExporter and AlertManager.
 - [Doku](https://github.com/amerkurev/doku) - Doku is a simple web-based application that allows you to monitor Docker disk usage. [amerkurev](https://github.com/amerkurev).


### PR DESCRIPTION
## What is DockProbe?

[DockProbe](https://github.com/deep-on/dockprobe) is a lightweight Docker monitoring dashboard that runs as a **single container**.

### Key Features
- 📊 Real-time container metrics (CPU, memory, network, disk)
- 🔍 **6 anomaly detection rules** (CPU spike, memory overflow, restart loop, etc.)
- 📱 Telegram alerts
- 🔒 16 automated security scans
- 🐳 Zero config — one `docker run` command
- ⚡ ~50MB RAM footprint, only 4 Python packages

### Why it fits
- Fully open source (MIT)
- Self-hosted, single container
- Fits the Docker monitoring use case not covered by other entries

```bash
docker run -d -p 8000:8000 -v /var/run/docker.sock:/var/run/docker.sock deeponinc/dockprobe
```