### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 
 - [cri-o](https://github.com/cri-o/cri-o) - Open Container Initiative-based implementation of Kubernetes Container Runtime Interface by [cri-o](https://github.com/cri-o).
 - [lxc](https://github.com/lxc/lxc) - LXC - Linux Containers.
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. By [us](https://github.com/us).
 - [podman](https://github.com/containers/libpod) - Libpod is a library used to create container pods. Home of Podman.
 - [rlxc](https://github.com/brauner/rlxc) :ice_cube: - LXC binary written in Rust.
 - [runtime-tools](https://github.com/opencontainers/runtime-tools) - Oci-runtime-tool is a collection of tools for working with the OCI runtime specification.


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built on Apple's Containerization framework.

- **License:** AGPL-3.0
- **Language:** Swift
- **Category:** Runtime

Added alphabetically to the Runtime section.