### PR TITLE
add tdocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Native desktop applications for managing and monitoring docker hosts and cluster
 - [lazydocker](https://github.com/jesseduffield/lazydocker) - The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library. By [jesseduffield](https://github.com/jesseduffield).
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) - A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.
 - [oxker](https://github.com/mrjackwills/oxker) - A simple tui to view & control docker containers. Written in [Rust](https://rust-lang.org/), making heavy use of [ratatui](https://github.com/tui-rs-revival/ratatui) & [Bollard](https://github.com/fussybeaver/bollard),.
+- [tdocker](https://github.com/pivovarit/tdocker) - A `docker ps` replacement for everyday container operations by [@pivovarit](https://github.com/pivovarit).
 
 ##### CLI tools
 


### PR DESCRIPTION
# Summary

Add tdocker - a `docker ps` replacement TUI for everyday container operations - to the Terminal UI section.  

## Scope

- [x] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

 - Category/section touched: User Interface > Terminal > Terminal UI                                                                                                      
 - New or updated project links: [tdocker](https://github.com/pivovarit/tdocker)

## Validation

- [x] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)

## Contributor Checklist

- [x] Entries are alphabetically ordered in their section
- [x] Links point to project repositories (no duplicates or redirects)
- [x] Descriptions are concise and specific
- [ ] Archived/deprecated projects were removed instead of tagged
- [ ] Used `:yen:` only when applicable
