### PR TITLE
Add SnapDeploy to PaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ _Source:_ [What is Docker](https://www.docker.com/why-docker/)
 - [Krane](https://github.com/krane/krane) :ice_cube: - Toolset for managing container workloads on remote servers.
 - [Nanobox](https://github.com/nanobox-io/nanobox) :ice_cube: - :yen: An application development platform that creates local environments that can then be deployed and scaled in the cloud.
 -   [OpenShift][openshift] - An open source PaaS built on [Kubernetes][kubernetes] and optimized for Dockerized app development and deployment by [Red Hat](https://www.redhat.com/en)
+- [SnapDeploy](https://snapdeploy.dev/) - A Docker-native container hosting platform with auto-sleep/wake, GitHub auto-deploy, and framework detection. Free tier available.
 - [Tsuru](https://github.com/tsuru/tsuru) - Tsuru is an extensible and open source Platform as a Service software.
 
 ### Reverse Proxy


### PR DESCRIPTION
Adding SnapDeploy to the PaaS section.

SnapDeploy is a Docker-native container hosting platform that deploys
containers from GitHub repos, Docker images, or uploaded artifacts.

Key features:
- Auto-detects frameworks (Node.js, Python, Java, Go, PHP, Ruby, .NET) and generates Dockerfiles
- GitHub integration with auto-deploy on push
- Auto-sleep/wake for idle containers
- Free SSL via Cloudflare
- Managed database add-ons

Available on GitHub Marketplace: https://github.com/marketplace/snapdeploy-app

Note: SnapDeploy is a commercial platform with a free tier, similar to
other PaaS entries in this section. It fits the "PaaS" category as it
provides a complete platform for operating Docker in production.