### PR TITLE
Add EasyDocker to Terminal UI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Native desktop applications for managing and monitoring docker hosts and cluster
 - [DockSTARTer](https://github.com/GhostWriters/DockSTARTer) - DockSTARTer helps you get started with home server apps running in Docker by [GhostWriters](https://github.com/GhostWriters).
 - [dprs](https://github.com/durableprogramming/dprs) - A developer-focused TUI for managing Docker containers with real-time log streaming and container management. Built with Rust. By [durableprogramming](https://github.com/durableprogramming).
 - [dry](https://github.com/moncho/dry) - An interactive CLI for Docker containers.
+- [easydocker](https://github.com/joao-zanutto/easydocker) - A Terminal UI highly inpired by k9s levaraging beatiful BubbleTea graphics. By [joao-zanutto](https://github.com/joao-zanutto).
 - [goManageDocker](https://github.com/ajayd-san/gomanagedocker) - TUI tool to view and manage your docker objects blazingly fast with sensible keybindings, also supports VIM navigation out of the box.
 - [lazydocker](https://github.com/jesseduffield/lazydocker) - The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library. By [jesseduffield](https://github.com/jesseduffield).
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) - A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.


### PR DESCRIPTION
# Summary

Adds [EasyDocker](https://github.com/joao-zanutto/easydocker) to Terminal UI tools.

EasyDocker is a TUI highly inspired in k9s that leverages beautiful BubbleTea graphics.

## Scope

- [x] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

- Category/section touched: Terminal UI tools
- New or updated project links: https://github.com/joao-zanutto/easydocker

## Validation

- [x] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)

## Contributor Checklist

- [x] Entries are alphabetically ordered in their section
- [x] Links point to project repositories (no duplicates or redirects)
- [x] Descriptions are concise and specific
- [ ] Archived/deprecated projects were removed instead of tagged
- [ ] Used `:yen:` only when applicable
