### PR TITLE
Add Middleware in Monitoring Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Services to securely store your Docker images.
 - [Broadcom Docker Monitoring](https://www.broadcom.com/info/aiops/docker-monitoring) - :yen: Agile Operations solutions from Broadcom deliver the modern Docker monitoring businesses need to accelerate and optimize the performance of microservices and the dynamic Docker environments running them. Monitor both the Docker environment and apps that run inside them. (former CA Technologies).
 -   [Collecting docker logs and stats with Splunk](https://www.splunk.com/en_us/blog/tips-and-tricks/collecting-docker-logs-and-stats-with-splunk.html)
 - [Datadog](https://www.datadoghq.com/) - :yen: Datadog is a full-stack monitoring service for large-scale cloud environments that aggregates metrics/events from servers, databases, and applications. It includes support for Docker, Kubernetes, and Mesos.
+- [Middleware](https://middleware.io/) - :yen: Middleware is a unified observability platform for monitoring docker containers, infrastructure, logs, traces, and application workloads from a single interface.
 - [Prometheus](https://prometheus.io/) - :yen: Open-source service monitoring system and time series database.
 - [Site24x7](https://www.site24x7.com/docker-monitoring.html) - :yen: Docker Monitoring for DevOps and IT is a SaaS Pay per Host model.
 - [SPM for Docker](https://github.com/sematext/sematext-agent-docker) :ice_cube: - :yen: Monitoring of host and container metrics, Docker events and logs. Automatic log parser. Anomaly Detection and alerting for metrics and logs. [sematext](https://github.com/sematext).


### PR DESCRIPTION
# Summary

Lists Middleware under Monitoring Services category. Middleware is  a full stack observability platform just like Datadog. It is cost effective because of usage based pricing rather than per host.

Many users have praised middleware's UI and ease of use. The listing follows alphabetical order and I think this tool is a valuable addition to the list.
## Scope

- [*] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

- Category/section touched: Monitoring Services
- New or updated project links: https://middleware.io/

## Validation

- [ ] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)

## Contributor Checklist

- [*] Entries are alphabetically ordered in their section
- [*] Links point to project repositories (no duplicates or redirects)
- [*] Descriptions are concise and specific
- [] Archived/deprecated projects were removed instead of tagged
- [*] Used `:yen:` only when applicable
