### PR TITLE
Remove outdated Docker links from README #HSFDPMUW

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,6 @@ Services to securely store your Docker images.
 
 # Useful Resources
 
--   **[Valuable Docker Links](http://nane.kratzke.pages.mylab.th-luebeck.de/about/blog/2014/08/24/valuable-docker-links/)** High quality articles about docker! **MUST SEE**
 -   [Cloud Native Landscape](https://github.com/cncf/landscape)
 - [Docker Blog](https://www.docker.com/blog/) - Regular updates about Docker, the community and tools.
 -   [Docker Certification](https://intellipaat.com/docker-training-course/?US) :yen: will help you to will Learn Docker containerization, running Docker containers, Image creation, Dockerfile, Docker orchestration, security best practices, and more through hands-on projects and case studies and helps to clear Docker Certified Associate.


### PR DESCRIPTION
# Summary

Removed a dead link to a blog about Docker from the Useful Resources section (returns 404/dead link).

## Scope

- [x] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

- Category/section touched: Useful Resources
- New or updated project links: N/A (Link removal only)

## Validation

- [x] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)

## Contributor Checklist

- [x] Entries are alphabetically ordered in their section
- [x] Links point to project repositories (no duplicates or redirects)
- [x] Descriptions are concise and specific
- [x] Archived/deprecated projects were removed instead of tagged
- [x] Used `:yen:` only when applicable