### PR TITLE
Add self-hosted-runner to CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ Services to securely store your Docker images.
 - [mu](https://github.com/stelligent/mu) :ice_cube: - Tool to configure CI/CD of your container applications via AWS CodePipeline, CodeBuild and ECS [Stelligent](https://github.com/stelligent).
 - [Popper](https://github.com/systemslab/popper) :ice_cube: - Github actions workflow (HCL syntax) execution engine.
 - [Screwdriver :yen:](https://screwdriver.cd/) - Yahoo's OpenSource buildplatform designed for Continous Delivery.
+* [Self Hosted Runner](https://github.com/youssefbrr/self-hosted-runner) - Dockerized solution for setting up a self-hosted GitHub Actions runner with support for Linux, macOS, and Windows. By [youssefbrr](https://github.com/youssefbrr).
 - [Skipper](https://github.com/Stratoscale/skipper) - Easily dockerize your Git repository.
 - [SwarmCI](https://github.com/ghostsquad/swarmci) :ice_cube: - Create a distributed, isolated task pipeline in your Docker Swarm.
 - [Tekton CD](https://tekton.dev/) - A cloud-native pipeline resource.


### PR DESCRIPTION
# Summary

Describe what changed and why.

## Scope

- [x] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

- Category/section touched: Development with Docker > CI/CD
- New or updated project links: https://github.com/youssefbrr/self-hosted-runner

## Validation

- [x] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)

## Contributor Checklist

- [x] Entries are alphabetically ordered in their section
- [x] Links point to project repositories (no duplicates or redirects)
- [x] Descriptions are concise and specific
- [ ] Archived/deprecated projects were removed instead of tagged
- [ ] Used `:yen:` only when applicable
