### PR TITLE
Add self-hosted-runner to CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Self-hosted CI engines, build accelerators, and hosted services that target Dock
 - [Jaypore CI](https://github.com/theSage21/jaypore_ci) - Simple, very flexible, powerful CI / CD / automation system configured in Python. Offline and local first.
 - [Kraken CI](https://github.com/Kraken-CI/kraken) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing. One of its executors is Docker. Developed.
 - [Screwdriver](https://screwdriver.cd/) - :yen: Yahoo's OpenSource buildplatform designed for Continous Delivery.
+- [Self Hosted Runner](https://github.com/youssefbrr/self-hosted-runner) - Dockerized solution for setting up a self-hosted GitHub Actions runner with support for Linux, macOS, and Windows. By [youssefbrr](https://github.com/youssefbrr).
 - [Semaphore CI](https://semaphore.io/) - :yen: High-performance cloud CI that builds, tests and ships containers to production.
 - [Skipper](https://github.com/Stratoscale/skipper) - Easily dockerize your Git repository.
 - [Tekton CD](https://tekton.dev/) - A cloud-native pipeline resource.

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Self-hosted CI engines, build accelerators, and hosted services that target Dock
 - [Jaypore CI](https://github.com/theSage21/jaypore_ci) - Simple, very flexible, powerful CI / CD / automation system configured in Python. Offline and local first.
 - [Kraken CI](https://github.com/Kraken-CI/kraken) - Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing. One of its executors is Docker. Developed.
 - [Screwdriver](https://screwdriver.cd/) - :yen: Yahoo's OpenSource buildplatform designed for Continous Delivery.
-- [Self Hosted Runner](https://github.com/youssefbrr/self-hosted-runner) - Dockerized solution for setting up a self-hosted GitHub Actions runner with support for Linux, macOS, and Windows. By [youssefbrr](https://github.com/youssefbrr).
+- [Self Hosted Runner](https://github.com/youssefbrr/self-hosted-runner) - Dockerized solution for setting up a self-hosted GitHub Actions runner with support for Linux, macOS, and Windows.
 - [Semaphore CI](https://semaphore.io/) - :yen: High-performance cloud CI that builds, tests and ships containers to production.
 - [Skipper](https://github.com/Stratoscale/skipper) - Easily dockerize your Git repository.
 - [Tekton CD](https://tekton.dev/) - A cloud-native pipeline resource.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to ____."*

If the blank doesn't contain **Docker, container, image, registry, Dockerfile, Compose, Swarm, BuildKit, or OCI**, it probably doesn't belong here.

What changed and why:


This project exists to deeply coupled with Docker ecosystem features rather than just being a standard application wrapped in a container. Here is how it directly relates to and leverages Docker:

Docker-in-Docker (DinD) & Workflow Isolation: The primary use case of this runner is to execute GitHub Actions workflows (which themselves often require running docker build or running test containers) entirely inside an isolated Docker container. It configures and optimizes the Docker socket binding safely.

Orchestration via Docker Compose: It utilizes docker-compose to allow DevOps engineers to horizontally scale their CI/CD infrastructure seamlessly (e.g., running docker-compose up --scale runner=5 to instantly spin up 5 parallel runners).

Multi-Platform Docker Architecture: The repository maintains specialized Dockerfile configurations and entrypoints to handle platform-specific nuances across Linux, Windows, and specifically macOS ARM64 (Apple Silicon) containers, which is a common pain point in containerized CI infrastructure.

Given that it provides a turnkey blueprint for orchestrating containerized CI/CD infrastructure via Docker, I believe it would be a highly relevant addition to the CI/CD section.


Best regards,
