### PR TITLE
feat: add prune subcommand, drop archived/stale entries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,74 @@
+# Sample golangci-lint config. Edit or delete to taste.
+# Full reference: https://golangci-lint.run/usage/configuration/
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - bodyclose       # checks HTTP response body is closed
+    - copyloopvar     # Go 1.22+ loop var capture
+    - dupword         # catches "the the"
+    - durationcheck   # multiplication of two durations
+    - embeddedstructfieldcheck
+    - errcheck        # unchecked errors
+    - errorlint       # errors.Is / errors.As hygiene
+    - forcetypeassert # type assertions without the comma-ok form
+    - gocritic        # opinionated diagnostics
+    - gosec           # security scanner
+    - govet           # stdlib vet
+    - ineffassign     # ineffectual assignments
+    - intrange        # prefer `for range N`
+    - misspell        # spelling
+    - modernize
+    - nilerr          # `return nil` after checking err != nil
+    - noctx           # http requests without context
+    - perfsprint      # fmt.Sprintf → string concat where safe
+    - prealloc        # slice preallocation hints
+    - staticcheck     # staticcheck.io
+    - unconvert       # redundant type conversions
+    - unparam         # unused function parameters
+    - unused          # dead code
+
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - shadow
+    staticcheck:
+      checks: ["all", "-QF1001", "-QF1002"] # drop quick-fix style nags
+    gocritic:
+      enabled-tags: [diagnostic, performance]
+      disabled-checks:
+        - hugeParam
+    gosec:
+      excludes:
+        - G104 # covered by errcheck
+        - G204 # subprocess with variable — allowed in CLI tooling
+        - G306 # 0600 file perms — CLIs often write executables
+
+  exclusions:
+    generated: lax
+    presets: [comments, common-false-positives, legacy, std-error-handling]
+    rules:
+      # Test code owns its fixtures.
+      - path: '_test\.go'
+        linters: [forcetypeassert, dupword, errcheck, gosec, unparam]
+      # CLI entry point: fmt.Fprint to stdout/stderr is fire-and-forget.
+      - linters: [errcheck]
+        source: 'fmt\.Fprint(ln|f)?\('
+
+issues:
+  max-issues-per-linter: 50
+  max-same-issues: 10
+
+formatters:
+  settings:
+    golines:
+      max-len: 120
+      tab-len: 8
+  enable:
+    - golines
+    - gofmt
+    - goimports

--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ Signing, attestation, and provenance for container images.
 - [plash](https://github.com/ihucos/plash) - A container run and build engine - runs inside docker.
 - [podman-compose](https://github.com/containers/podman-compose) - A script to run docker-compose.yml using podman.
 - [Smalte](https://github.com/roquie/smalte) – Dynamically configure applications that require static configuration in docker container.
-- [Stitchocker](https://github.com/alexaandrov/stitchocker) - A lightweight and fast command line utility for conveniently grouping your docker-compose multiple container services.
 
 ### Orchestration
 
@@ -278,7 +277,6 @@ Self-hosted and managed cloud platforms (PaaS/CaaS, deployment automation). Comm
 Container networking, overlay networks, DNS/service-discovery bridges.
 
 - [Calico][calico] - Calico is a pure layer 3 virtual network that allows containers over multiple docker-hosts to talk to each other.
-- [docker-consul](https://github.com/gliderlabs/docker-consul) - Consul packaged for Docker — registers and discovers running containers.
 - [docker-dns](https://github.com/bytesharky/docker-dns) - Lightweight DNS forwarder for Docker containers, resolves container names with custom suffixes (e.g. `.docker`) on the host to simplify service discovery.
 - [Flannel](https://github.com/coreos/flannel/) - Flannel is a virtual network that gives a subnet to each host for use with container runtimes.
 - [netshoot](https://github.com/nicolaka/netshoot) - The netshoot container has a powerful set of networking tools to help troubleshoot Docker networking issues.
@@ -286,6 +284,8 @@ Container networking, overlay networks, DNS/service-discovery bridges.
 - [registrator](https://github.com/gliderlabs/registrator) - Service registry bridge for Docker.
 
 ### Reverse Proxy
+
+Container-aware reverse proxies, ingress, and TLS-terminating front-ends with auto-discovery.
 
 - [BunkerWeb](https://github.com/bunkerity/bunkerweb) - Open-source and next-gen Web Application Firewall (WAF).
 - [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) - Caddy-based reverse proxy, configured with service or container labels.
@@ -302,7 +302,6 @@ Container networking, overlay networks, DNS/service-discovery bridges.
 
 ## Storage & Data
 
-- [Blockbridge](https://github.com/blockbridge/blockbridge-docker-volume) - :yen: The Blockbridge plugin is a volume plugin that provides access to an extensible set of container-based persistent storage options. It supports single and multi-host Docker environments with features that include tenant isolation, automated provisioning, encryption, secure deletion, snapshots and QoS.
 - [Label Backup](https://github.com/resulgg/label-backup) - A lightweight, Docker-aware backup agent that automatically discovers and backs up containerized databases (PostgreSQL, MySQL, MongoDB, Redis) based on Docker labels. Supports local storage and S3-compatible destinations with flexible scheduling via cron expressions.
 - [Docker Volume Backup](https://github.com/offen/docker-volume-backup) Backup Docker volumes locally or to any S3 compatible storage.
 - [Netshare](https://github.com/ContainX/docker-volume-netshare) Docker NFS, AWS EFS, Ceph & Samba/CIFS Volume Plugin.
@@ -345,10 +344,10 @@ Container hardening, runtime security, policy, compliance, and forensics. Self-h
 - [buildcage](https://github.com/dash14/buildcage) - Restricts outbound network access during Docker builds to prevent supply chain attacks, working as a drop-in BuildKit remote driver for Docker Buildx, with ready-to-use GitHub Actions.
 - [CetusGuard](https://github.com/hectorm/cetusguard) - CetusGuard is a tool that protects the Docker daemon socket by filtering calls to its API endpoints.
 - [Checkov](https://github.com/bridgecrewio/checkov) - Static analysis for infrastructure as code manifests (Terraform, Kubernetes, Cloudformation, Helm, Dockerfile, Kustomize) find security misconfiguration and fix them.
+- [container-explorer](https://github.com/google/container-explorer) - Forensic utility to explore Docker and containerd container details from mounted disk images.
 - [Deepfence Threat Mapper](https://github.com/deepfence/ThreatMapper) - Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Den](https://github.com/us/den) - Self-hosted sandbox runtime for AI agents with Docker containers, security hardening, REST API and WebSocket support.
 - [docker-bench-security](https://github.com/docker/docker-bench-security) - Script that checks for dozens of common best-practices around deploying Docker containers in production.
-- [docker-explorer](https://github.com/google/docker-explorer) - A tool to help forensicate offline docker acquisitions.
 - [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) - HAProxy-based fine-grained filter for the Docker API socket; widely used to expose a restricted socket to reverse proxies and homelab stacks.
 - [KICS](https://github.com/checkmarx/kics) - An infrastructure-as-code scanning tool, find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle. Can be extended for additional policies.
 - [Prisma Cloud](https://www.paloaltonetworks.com/prisma/cloud) - :yen: (Previously Twistlock Security Suite) detects vulnerabilities, hardens container images, and enforces security policies across the lifecycle of applications.
@@ -377,7 +376,6 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [dctl](https://github.com/FabienD/docker-stack) - Dctl is a Cli tool that helps developers by allowing them to execute all docker compose commands anywhere in the terminal, and more.
 - [decompose](https://github.com/s0rg/decompose) - Reverse-engineering tool for docker environments.
 - [dive](https://github.com/wagoodman/dive) - A tool for exploring each layer in a docker image.
-- [dockdash](https://github.com/byrnedo/dockdash) - Detailed Docker container stats.
 - [docker pushrm](https://github.com/christian-korneck/docker-pushrm) - A Docker CLI plugin that lets you push the README.md file from the current directory to Docker Hub. Also supports Quay and Harbor.
 - [docker-captain](https://github.com/lucabello/docker-captain) - A friendly CLI to manage multiple Docker Compose deployments with style — powered by Typer, Rich, questionary, and sh.
 - [dockerfile-mode](https://github.com/spotify/dockerfile-mode) - An Emacs mode for handling Dockerfiles.

--- a/cmd/awesome-docker/main.go
+++ b/cmd/awesome-docker/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/veggiemonk/awesome-docker/internal/checker"
 	"github.com/veggiemonk/awesome-docker/internal/linter"
 	"github.com/veggiemonk/awesome-docker/internal/parser"
+	"github.com/veggiemonk/awesome-docker/internal/pruner"
 	"github.com/veggiemonk/awesome-docker/internal/scorer"
 	"github.com/veggiemonk/awesome-docker/internal/tui"
 )
@@ -52,6 +53,7 @@ func main() {
 		validateCmd(),
 		ciCmd(),
 		browseCmd(),
+		pruneCmd(),
 	)
 
 	if err := root.Execute(); err != nil {
@@ -699,5 +701,110 @@ func browseCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&cachePath, "cache", healthCachePath, "Path to health cache YAML")
+	return cmd
+}
+
+func pruneCmd() *cobra.Command {
+	var (
+		statuses   []string
+		dryRun     bool
+		keepCache  bool
+		fromReport string
+	)
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove README entries by health status (default: archived, stale)",
+		Long: `Remove entries from README.md whose repository health status matches the
+given list (default: "archived,stale"). The matching cache entries are also
+dropped so the next health refresh starts from a clean slate.
+
+By default the target URL list is read from the local health cache. Refresh
+it first with:
+
+    awesome-docker health
+
+If the local cache is outdated (e.g. you only have the markdown report from
+a CI-generated issue), point --from-report at the saved markdown report file
+and the URLs will be parsed from its section headings instead.
+
+Use --dry-run to preview what would be removed without writing files.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				targets map[string]cache.HealthEntry
+				hc      *cache.HealthCache
+			)
+
+			if fromReport != "" {
+				f, err := os.Open(fromReport) //nolint:gosec
+				if err != nil {
+					return fmt.Errorf("open report: %w", err)
+				}
+				defer f.Close()
+				targets, err = pruner.TargetsFromReport(f, statuses)
+				if err != nil {
+					return fmt.Errorf("parse report: %w", err)
+				}
+			} else {
+				var err error
+				hc, err = cache.LoadHealthCache(healthCachePath)
+				if err != nil {
+					return fmt.Errorf("load cache: %w", err)
+				}
+				if len(hc.Entries) == 0 {
+					return fmt.Errorf("no cache data; run 'awesome-docker health' first")
+				}
+				targets = pruner.TargetURLs(hc, statuses)
+			}
+
+			if len(targets) == 0 {
+				fmt.Printf("No entries match statuses %v; nothing to do\n", statuses)
+				return nil
+			}
+
+			res, err := pruner.PruneREADME(readmePath, targets, dryRun)
+			if err != nil {
+				return fmt.Errorf("prune readme: %w", err)
+			}
+
+			byStatus := map[string]int{}
+			for _, r := range res.Removed {
+				byStatus[r.Status]++
+			}
+			action := "Removed"
+			if dryRun {
+				action = "Would remove"
+			}
+			fmt.Printf("%s %d entries from %s\n", action, len(res.Removed), readmePath)
+			for s, n := range byStatus {
+				fmt.Printf("  %s: %d\n", s, n)
+			}
+			for _, r := range res.Removed {
+				fmt.Printf("  - [%s] %s (%s)\n", r.Status, r.Name, r.URL)
+			}
+			if len(res.NotFound) > 0 {
+				fmt.Printf("\n%d target URLs not found in README (already pruned or URL drift):\n", len(res.NotFound))
+				for _, u := range res.NotFound {
+					fmt.Printf("  %s\n", u)
+				}
+			}
+
+			if !keepCache && hc != nil {
+				dropped, err := pruner.PruneCache(healthCachePath, hc, targets, dryRun)
+				if err != nil {
+					return fmt.Errorf("prune cache: %w", err)
+				}
+				cacheAction := "Removed"
+				if dryRun {
+					cacheAction = "Would remove"
+				}
+				fmt.Printf("\n%s %d cache entries from %s\n", cacheAction, dropped, healthCachePath)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&statuses, "status", []string{"archived", "stale"}, "Comma-separated health statuses to prune (archived,stale,inactive,dead)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would be removed without writing files")
+	cmd.Flags().BoolVar(&keepCache, "keep-cache", false, "Do not remove pruned URLs from the health cache")
+	cmd.Flags().StringVar(&fromReport, "from-report", "", "Read target URLs from a markdown health report file instead of the cache")
 	return cmd
 }

--- a/cmd/awesome-docker/main.go
+++ b/cmd/awesome-docker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -28,11 +29,11 @@ const (
 )
 
 type checkSummary struct {
-	ExternalTotal int
-	GitHubTotal   int
 	Broken        []checker.LinkResult
 	Redirected    []checker.LinkResult
 	GitHubErrors  []error
+	ExternalTotal int
+	GitHubTotal   int
 	GitHubSkipped bool
 }
 
@@ -156,7 +157,7 @@ func runLinkChecks(prMode bool) (checkSummary, error) {
 func runHealth(ctx context.Context) error {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		return fmt.Errorf("GITHUB_TOKEN environment variable is required")
+		return errors.New("GITHUB_TOKEN environment variable is required")
 	}
 
 	doc, err := parseReadme()
@@ -176,9 +177,12 @@ func runHealth(ctx context.Context) error {
 	}
 	if len(infos) == 0 {
 		if len(errs) > 0 {
-			return fmt.Errorf("failed to fetch GitHub metadata for all repositories (%d errors); check network/DNS and GITHUB_TOKEN", len(errs))
+			return fmt.Errorf(
+				"failed to fetch GitHub metadata for all repositories (%d errors); check network/DNS and GITHUB_TOKEN",
+				len(errs),
+			)
 		}
-		return fmt.Errorf("no GitHub repositories found in README")
+		return errors.New("no GitHub repositories found in README")
 	}
 
 	scored := scorer.ScoreAll(infos)
@@ -213,11 +217,12 @@ func scoredFromCache() ([]scorer.ScoredEntry, error) {
 		return nil, fmt.Errorf("load cache: %w", err)
 	}
 	if len(hc.Entries) == 0 {
-		return nil, fmt.Errorf("no cache data, run 'health' first")
+		return nil, errors.New("no cache data, run 'health' first")
 	}
 
 	scored := make([]scorer.ScoredEntry, 0, len(hc.Entries))
-	for _, e := range hc.Entries {
+	for i := range hc.Entries {
+		e := &hc.Entries[i]
 		scored = append(scored, scorer.ScoredEntry{
 			URL:         e.URL,
 			Name:        e.Name,
@@ -411,7 +416,11 @@ func checkCmd() *cobra.Command {
 				}
 			}
 			if len(summary.Broken) > 0 && len(summary.GitHubErrors) > 0 {
-				return fmt.Errorf("found %d broken links and %d GitHub API errors", len(summary.Broken), len(summary.GitHubErrors))
+				return fmt.Errorf(
+					"found %d broken links and %d GitHub API errors",
+					len(summary.Broken),
+					len(summary.GitHubErrors),
+				)
 			}
 			if len(summary.Broken) > 0 {
 				return fmt.Errorf("found %d broken links", len(summary.Broken))
@@ -562,20 +571,40 @@ func ciBrokenLinksCmd() *cobra.Command {
 				}
 			}
 
-			if err := writeGitHubOutput(githubOutput, "has_errors", strconv.FormatBool(hasErrors)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"has_errors",
+				strconv.FormatBool(hasErrors),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "check_exit_code", strconv.Itoa(exitCode)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"check_exit_code",
+				strconv.Itoa(exitCode),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "broken_count", strconv.Itoa(len(summary.Broken))); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"broken_count",
+				strconv.Itoa(len(summary.Broken)),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "github_error_count", strconv.Itoa(len(summary.GitHubErrors))); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"github_error_count",
+				strconv.Itoa(len(summary.GitHubErrors)),
+			); err != nil {
 				return err
 			}
 			if runErr != nil {
-				if err := writeGitHubOutput(githubOutput, "run_error", sanitizeOutputValue(runErr.Error())); err != nil {
+				if err := writeGitHubOutput(
+					githubOutput,
+					"run_error",
+					sanitizeOutputValue(runErr.Error()),
+				); err != nil {
 					return err
 				}
 			}
@@ -584,7 +613,11 @@ func ciBrokenLinksCmd() *cobra.Command {
 				fmt.Printf("CI broken-links run error: %v\n", runErr)
 			}
 			if hasErrors {
-				fmt.Printf("CI broken-links found %d broken links and %d GitHub errors\n", len(summary.Broken), len(summary.GitHubErrors))
+				fmt.Printf(
+					"CI broken-links found %d broken links and %d GitHub errors\n",
+					len(summary.Broken),
+					len(summary.GitHubErrors),
+				)
 			} else {
 				fmt.Println("CI broken-links found no errors")
 			}
@@ -594,7 +627,11 @@ func ciBrokenLinksCmd() *cobra.Command {
 					return runErr
 				}
 				if hasErrors {
-					return fmt.Errorf("found %d broken links and %d GitHub API errors", len(summary.Broken), len(summary.GitHubErrors))
+					return fmt.Errorf(
+						"found %d broken links and %d GitHub API errors",
+						len(summary.Broken),
+						len(summary.GitHubErrors),
+					)
 				}
 			}
 			return nil
@@ -602,7 +639,8 @@ func ciBrokenLinksCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&issueFile, "issue-file", "broken_links_issue.md", "Path to write issue markdown body")
-	cmd.Flags().StringVar(&githubOutput, "github-output", "", "Path to GitHub output file (typically $GITHUB_OUTPUT)")
+	cmd.Flags().
+		StringVar(&githubOutput, "github-output", "", "Path to GitHub output file (typically $GITHUB_OUTPUT)")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Return non-zero when errors are found")
 	return cmd
 }
@@ -631,25 +669,49 @@ func ciHealthReportCmd() *cobra.Command {
 				}
 			}
 
-			if err := writeGitHubOutput(githubOutput, "has_report", strconv.FormatBool(hasReport)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"has_report",
+				strconv.FormatBool(hasReport),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "health_ok", strconv.FormatBool(healthOK)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"health_ok",
+				strconv.FormatBool(healthOK),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "report_ok", strconv.FormatBool(reportOK)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"report_ok",
+				strconv.FormatBool(reportOK),
+			); err != nil {
 				return err
 			}
-			if err := writeGitHubOutput(githubOutput, "has_errors", strconv.FormatBool(hasErrors)); err != nil {
+			if err := writeGitHubOutput(
+				githubOutput,
+				"has_errors",
+				strconv.FormatBool(hasErrors),
+			); err != nil {
 				return err
 			}
 			if healthErr != nil {
-				if err := writeGitHubOutput(githubOutput, "health_error", sanitizeOutputValue(healthErr.Error())); err != nil {
+				if err := writeGitHubOutput(
+					githubOutput,
+					"health_error",
+					sanitizeOutputValue(healthErr.Error()),
+				); err != nil {
 					return err
 				}
 			}
 			if reportErr != nil {
-				if err := writeGitHubOutput(githubOutput, "report_error", sanitizeOutputValue(reportErr.Error())); err != nil {
+				if err := writeGitHubOutput(
+					githubOutput,
+					"report_error",
+					sanitizeOutputValue(reportErr.Error()),
+				); err != nil {
 					return err
 				}
 			}
@@ -679,7 +741,8 @@ func ciHealthReportCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&issueFile, "issue-file", "health_report.txt", "Path to write health issue markdown body")
-	cmd.Flags().StringVar(&githubOutput, "github-output", "", "Path to GitHub output file (typically $GITHUB_OUTPUT)")
+	cmd.Flags().
+		StringVar(&githubOutput, "github-output", "", "Path to GitHub output file (typically $GITHUB_OUTPUT)")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Return non-zero when health/report fails")
 	return cmd
 }
@@ -695,7 +758,7 @@ func browseCmd() *cobra.Command {
 				return fmt.Errorf("load cache: %w", err)
 			}
 			if len(hc.Entries) == 0 {
-				return fmt.Errorf("no cache data; run 'awesome-docker health' first")
+				return errors.New("no cache data; run 'awesome-docker health' first")
 			}
 			return tui.Run(hc.Entries)
 		},
@@ -751,7 +814,7 @@ Use --dry-run to preview what would be removed without writing files.`,
 					return fmt.Errorf("load cache: %w", err)
 				}
 				if len(hc.Entries) == 0 {
-					return fmt.Errorf("no cache data; run 'awesome-docker health' first")
+					return errors.New("no cache data; run 'awesome-docker health' first")
 				}
 				targets = pruner.TargetURLs(hc, statuses)
 			}
@@ -782,7 +845,10 @@ Use --dry-run to preview what would be removed without writing files.`,
 				fmt.Printf("  - [%s] %s (%s)\n", r.Status, r.Name, r.URL)
 			}
 			if len(res.NotFound) > 0 {
-				fmt.Printf("\n%d target URLs not found in README (already pruned or URL drift):\n", len(res.NotFound))
+				fmt.Printf(
+					"\n%d target URLs not found in README (already pruned or URL drift):\n",
+					len(res.NotFound),
+				)
 				for _, u := range res.NotFound {
 					fmt.Printf("  %s\n", u)
 				}
@@ -802,9 +868,11 @@ Use --dry-run to preview what would be removed without writing files.`,
 			return nil
 		},
 	}
-	cmd.Flags().StringSliceVar(&statuses, "status", []string{"archived", "stale"}, "Comma-separated health statuses to prune (archived,stale,inactive,dead)")
+	cmd.Flags().
+		StringSliceVar(&statuses, "status", []string{"archived", "stale"}, "Comma-separated health statuses to prune (archived,stale,inactive,dead)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would be removed without writing files")
 	cmd.Flags().BoolVar(&keepCache, "keep-cache", false, "Do not remove pruned URLs from the health cache")
-	cmd.Flags().StringVar(&fromReport, "from-report", "", "Read target URLs from a markdown health report file instead of the cache")
+	cmd.Flags().
+		StringVar(&fromReport, "from-report", "", "Read target URLs from a markdown health report file instead of the cache")
 	return cmd
 }

--- a/config/health_cache.yaml
+++ b/config/health_cache.yaml
@@ -1,1907 +1,181 @@
 entries:
-    - url: https://github.com/byrnedo/capitan
-      name: byrnedo/capitan
-      status: stale
-      stars: 31
-      last_push: 2017-06-07T09:46:56Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Composable docker orchestration with added scripting support by [byrnedo].
-    - url: https://github.com/magicmark/composerize
-      name: magicmark/composerize
+    - url: https://github.com/docker/compose
+      name: docker/compose
       status: healthy
-      stars: 3703
-      forks: 247
-      last_push: 2026-01-17T12:14:28Z
+      stars: 37391
+      forks: 5810
+      last_push: 2026-05-18T15:28:07Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Convert docker run commands into docker-compose files.
-    - url: https://github.com/polonskiy/crowdr
-      name: polonskiy/crowdr
-      status: stale
-      stars: 98
-      forks: 9
-      last_push: 2020-10-09T07:57:52Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Tool for managing multiple Docker containers (`docker-compose` alternative).
-    - url: https://github.com/ctk-hq/ctk
-      name: ctk-hq/ctk
+      checked_at: 2026-05-18T21:29:20.484404Z
+    - url: https://github.com/abiosoft/colima
+      name: abiosoft/colima
       status: healthy
-      stars: 298
-      forks: 27
-      last_push: 2026-02-15T22:53:00Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Visual composer for container based workloads. By [corpulent](https://github.com/corpulent).
-    - url: https://github.com/sudo-bmitch/docker-config-update
-      name: sudo-bmitch/docker-config-update
-      status: stale
-      stars: 51
-      forks: 8
-      last_push: 2023-03-30T13:03:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Utility to update docker configs and secrets for deploying in a compose file.
-    - url: https://github.com/cisco/elsy
-      name: cisco/elsy
-      status: stale
-      stars: 80
-      forks: 22
-      last_push: 2022-01-18T13:38:49Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: An opinionated, multi-language, build tool based on Docker and Docker Compose.
-    - url: https://github.com/cloud66-oss/habitus
-      name: cloud66-oss/habitus
-      status: stale
-      stars: 1392
-      forks: 81
-      last_push: 2020-02-05T17:10:30Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: A Build Flow Tool for Docker.
-    - url: https://github.com/kubernetes/kompose
-      name: kubernetes/kompose
-      status: healthy
-      stars: 10464
-      forks: 794
-      last_push: 2026-02-27T14:23:27Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: Go from Docker Compose to Kubernetes.
-    - url: https://github.com/av/harbor
-      name: av/harbor
-      status: healthy
-      stars: 2485
-      forks: 166
-      last_push: 2026-03-08T14:30:46Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: A CLI and companion app to effortlessly run LLM backends, APIs, frontends, and services with one command. By [av](https://github.com/av).
-    - url: https://github.com/ihucos/plash
-      name: ihucos/plash
-      status: healthy
-      stars: 387
-      forks: 15
-      last_push: 2025-03-20T15:47:21Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: A container run and build engine - runs inside docker.
-    - url: https://github.com/containers/podman-compose
-      name: containers/podman-compose
-      status: healthy
-      stars: 5990
+      stars: 28876
       forks: 577
-      last_push: 2026-03-05T16:25:54Z
+      last_push: 2026-05-18T19:53:51Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: A script to run docker-compose.yml using podman.
-    - url: https://github.com/alexaandrov/stitchocker
-      name: alexaandrov/stitchocker
-      status: inactive
-      stars: 30
-      forks: 2
-      last_push: 2024-03-14T13:50:30Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Container Composition
-      description: A lightweight and fast command line utility for conveniently grouping your docker-compose multiple container services. By [alexaandrov](https://github.com/alexaandrov).
-    - url: https://github.com/ethibox/awesome-stacks
-      name: ethibox/awesome-stacks
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: Container runtimes on macOS (and Linux) with minimal setup.
+    - url: https://github.com/containerd/containerd
+      name: containerd/containerd
       status: healthy
-      stars: 1250
-      forks: 162
-      last_push: 2026-03-08T14:40:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Deploy 150+ open-source web apps with one Docker command.
-    - url: https://github.com/newrelic/centurion
-      name: newrelic/centurion
-      status: archived
-      stars: 1757
-      forks: 112
-      last_push: 2025-09-11T20:47:50Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Centurion is a mass deployment tool for Docker fleets. It takes containers from a Docker registry and runs them on a fleet of hosts with the correct environment variables, host volume mappings, and port mappings. By [newrelic](https://github.com/newrelic).
-    - url: https://github.com/brooklyncentral/clocker
-      name: brooklyncentral/clocker
-      status: stale
-      stars: 429
-      forks: 64
-      last_push: 2018-10-24T15:29:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Clocker creates and manages a Docker cloud infrastructure. Clocker supports single-click deployments and runtime management of multi-node applications that run as containers distributed across multiple hosts, on both Docker and Marathon. It leverages [Calico][calico] and [Weave][weave] for networking and [Brooklyn](https://brooklyn.apache.org/) for application blueprints. By [brooklyncentral](https://github.com/brooklyncentral).
-    - url: https://github.com/ehazlett/conduit
-      name: ehazlett/conduit
-      status: stale
-      stars: 108
-      forks: 11
-      last_push: 2016-11-07T18:20:56Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Experimental deployment system for Docker.
-    - url: https://github.com/ContainX/depcon
-      name: ContainX/depcon
-      status: stale
-      stars: 93
-      forks: 15
-      last_push: 2018-06-05T04:40:23Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Depcon is written in Go and allows you to easily deploy Docker containers to Apache Mesos/Marathon, Amazon ECS and Kubernetes. By [ContainX][containx].
-    - url: https://github.com/deploystackio/docker-to-iac
-      name: deploystackio/docker-to-iac
-      status: healthy
-      stars: 23
-      last_push: 2026-03-02T06:11:33Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Translate docker run and commit into Infrastructure as Code templates for AWS, Render.com and DigitalOcean.
-    - url: https://github.com/hasura/gitkube
-      name: hasura/gitkube
-      status: stale
-      stars: 3850
-      forks: 203
-      last_push: 2023-08-31T07:48:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Gitkube is a tool for building and deploying docker images on Kubernetes using `git push`. By [Hasura](https://github.com/hasura/).
-    - url: https://github.com/grafeas/grafeas
-      name: grafeas/grafeas
-      status: healthy
-      stars: 1564
-      forks: 307
-      last_push: 2026-02-13T21:53:15Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: A common API for metadata about containers, from image and build details to security vulnerabilities. By [grafeas](https://github.com/grafeas).
-    - url: https://github.com/LombardiDaniel/swarm-ansible
-      name: LombardiDaniel/swarm-ansible
-      status: healthy
-      stars: 59
-      forks: 4
-      last_push: 2026-01-24T22:01:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-    - url: https://github.com/hansehe/SwarmManagement
-      name: hansehe/SwarmManagement
-      status: healthy
-      stars: 21
-      forks: 1
-      last_push: 2025-05-13T15:24:25Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Swarm Management is a python application, installed with pip. The application makes it easy to manage a Docker Swarm by configuring a single yaml file describing which stacks to deploy, and which networks, configs or secrets to create.
-    - url: https://github.com/werf/werf
-      name: werf/werf
-      status: healthy
-      stars: 4661
-      forks: 230
-      last_push: 2026-03-06T15:47:09Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Deployment and Infrastructure
-      description: Werf is a CI/CD tool for building Docker images efficiently and deploying them to Kubernetes using GitOps.
-    - url: https://github.com/willfarrell/docker-autoheal
-      name: willfarrell/docker-autoheal
-      status: healthy
-      stars: 1801
-      forks: 254
-      last_push: 2025-09-09T16:33:25Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Monitor and restart unhealthy docker containers automatically.
-    - url: https://github.com/google/cadvisor
-      name: google/cadvisor
-      status: healthy
-      stars: 18952
-      forks: 2461
-      last_push: 2026-03-02T18:35:32Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Analyzes resource usage and performance characteristics of running containers.
-    - url: https://github.com/bluewave-labs/checkmate
-      name: bluewave-labs/checkmate
-      status: healthy
-      stars: 9372
-      forks: 680
-      last_push: 2026-03-07T01:22:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Checkmate is an open-source, self-hosted tool designed to track and monitor server hardware, uptime, response times, and incidents in real-time with beautiful visualizations.
-    - url: https://github.com/zorak1103/dlia
-      name: zorak1103/dlia
-      status: healthy
-      stars: 3
-      last_push: 2026-03-07T04:03:52Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: DLIA is an AI-powered Docker log monitoring agent that uses Large Language Models (LLMs) to intelligently analyze container logs, detect anomalies, and provide contextual insights over time. By [zorak1103](https://github.com/zorak1103).
-    - url: https://github.com/deltaskelta/docker-alertd
-      name: deltaskelta/docker-alertd
-      status: stale
-      stars: 108
-      forks: 12
-      last_push: 2017-11-15T04:40:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Monitor and send alerts based on docker container resource usage/statistics.
-    - url: https://github.com/docker-flow/docker-flow-monitor
-      name: docker-flow/docker-flow-monitor
-      status: stale
-      stars: 88
-      forks: 38
-      last_push: 2021-03-17T14:33:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Reconfigures Prometheus when a new service is updated or deployed automatically.
-    - url: https://github.com/stefanprodan/dockprom
-      name: stefanprodan/dockprom
-      status: healthy
-      stars: 6488
-      forks: 1768
-      last_push: 2026-03-06T05:28:07Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Docker hosts and containers monitoring with Prometheus, Grafana, cAdvisor, NodeExporter and AlertManager.
-    - url: https://github.com/amerkurev/doku
-      name: amerkurev/doku
-      status: healthy
-      stars: 410
-      forks: 18
-      last_push: 2025-12-26T09:13:21Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Doku is a simple web-based application that allows you to monitor Docker disk usage. [amerkurev](https://github.com/amerkurev).
-    - url: https://github.com/nicolargo/glances
-      name: nicolargo/glances
-      status: healthy
-      stars: 31995
-      forks: 1695
-      last_push: 2026-03-07T15:24:35Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: A cross-platform curses-based system monitoring tool written in Python.
-    - url: https://github.com/dromara/hertzbeat
-      name: dromara/hertzbeat
-      status: healthy
-      stars: 7114
-      forks: 1255
-      last_push: 2026-03-08T12:09:09Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: An open-source real-time monitoring system with custom-monitor and agentless.
-    - url: https://github.com/vegasbrianc/docker-monitoring
-      name: vegasbrianc/docker-monitoring
-      status: stale
-      stars: 473
-      forks: 129
-      last_push: 2018-06-10T20:53:49Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: InfluxDB Time series DB in combination with Grafana and cAdvisor.
-    - url: https://github.com/gliderlabs/logspout
-      name: gliderlabs/logspout
-      status: stale
-      stars: 4701
-      forks: 668
-      last_push: 2023-07-11T20:36:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Log routing for Docker container logs.
-    - url: https://github.com/decryptus/monit-docker
-      name: decryptus/monit-docker
-      status: stale
-      stars: 34
-      forks: 5
-      last_push: 2023-01-16T11:31:14Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Monitor docker containers resources usage or status and execute docker commands or inside containers. [decryptus][decryptus].
-    - url: https://github.com/NexClipper/NexClipper
-      name: NexClipper/NexClipper
-      status: stale
-      stars: 565
-      forks: 72
-      last_push: 2023-05-05T02:21:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: NexClipper is the container monitoring and performance management solution specialized in Docker, Apache Mesos, Marathon, DC/OS, Mesosphere, Kubernetes.
-    - url: https://github.com/uschtwill/docker_monitoring_logging_alerting
-      name: uschtwill/docker_monitoring_logging_alerting
-      status: stale
-      stars: 539
-      forks: 119
-      last_push: 2018-09-13T07:36:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Docker host and container monitoring, logging and alerting out of the box using cAdvisor, Prometheus, Grafana for monitoring, Elasticsearch, Kibana and Logstash for logging and elastalert and Alertmanager for alerting. Set up in 5 Minutes. Secure mode for production use with built-in [Automated Nginx Reverse Proxy (jwilder's)][nginxproxy].
-    - url: https://github.com/runsidekick/sidekick
-      name: runsidekick/sidekick
-      status: stale
-      stars: 1611
-      forks: 67
-      last_push: 2023-06-29T12:18:38Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Open source live application debugger like Chrome DevTools for your backend. Collect traces and generate logs on-demand without stopping & redeploying your applications.
-    - url: https://github.com/gpulido/SwarmAlert
-      name: gpulido/SwarmAlert
-      status: stale
-      stars: 22
-      forks: 2
-      last_push: 2019-11-27T12:17:14Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Monitors a Docker Swarm and sends Pushover alerts when it finds a container with no healthy service task running.
-    - url: https://github.com/gomex/docker-zabbix
-      name: gomex/docker-zabbix
-      status: stale
-      stars: 53
-      forks: 12
-      last_push: 2017-07-28T14:29:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Monitor containers automatically using zabbix LLD feature.
-    - url: https://github.com/monitoringartist/Zabbix-Docker-Monitoring
-      name: monitoringartist/Zabbix-Docker-Monitoring
-      status: stale
-      stars: 1197
-      forks: 265
-      last_push: 2022-02-22T17:01:39Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Monitoring
-      description: Zabbix module that provides discovery of running containers, CPU/memory/blk IO/net container metrics. Systemd Docker and LXC execution driver is also supported. It's a dynamically linked shared object library, so its performance is (~10x) better, than any script solution.
-    - url: https://github.com/coreos/flannel
-      name: coreos/flannel
-      status: healthy
-      stars: 9410
-      forks: 2902
-      last_push: 2026-03-06T12:10:23Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-    - url: https://github.com/Microsoft/Freeflow
-      name: Microsoft/Freeflow
-      status: stale
-      stars: 632
-      forks: 96
-      last_push: 2023-06-12T19:30:22Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Networking
-      description: High performance container overlay networks on Linux. Enabling RDMA (on both InfiniBand and RoCE) and accelerating TCP to bare metal performance. By [Microsoft](https://github.com/Microsoft).
-    - url: https://github.com/jason5ng32/MyIP
-      name: jason5ng32/MyIP
-      status: healthy
-      stars: 9895
-      forks: 1072
-      last_push: 2026-02-10T07:38:47Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Networking
-      description: All in one IP Toolbox. Easy to check all your IPs, IP geolocation, check for DNS leaks, examine WebRTC connections, speed test, ping test, MTR test, check website availability, whois search and more. By [jason5ng32](https://github.com/jason5ng32).
-    - url: https://github.com/nicolaka/netshoot
-      name: nicolaka/netshoot
-      status: healthy
-      stars: 10445
-      forks: 1085
-      last_push: 2026-03-05T17:23:33Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Networking
-      description: The netshoot container has a powerful set of networking tools to help troubleshoot Docker networking issues.
-    - url: https://github.com/jpetazzo/pipework
-      name: jpetazzo/pipework
-      status: inactive
-      stars: 4252
-      forks: 727
-      last_push: 2024-11-04T17:31:57Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Networking
-      description: Software-Defined Networking for Linux Containers, Pipework works with "plain" LXC containers, and with the awesome Docker. By [jpetazzo][jpetazzo].
-    - url: https://github.com/Peco602/ansible-linux-docker
-      name: Peco602/ansible-linux-docker
-      status: stale
-      stars: 37
-      forks: 4
-      last_push: 2023-06-21T09:34:02Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Run Ansible from a Linux container. By [Peco602][peco602].
-    - url: https://github.com/athena-oss/athena
-      name: athena-oss/athena
-      status: stale
-      stars: 96
-      forks: 25
-      last_push: 2017-07-06T08:26:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: An automation platform with a plugin architecture that allows you to easily create and share services.
-    - url: https://github.com/CloudSlang/cloud-slang
-      name: CloudSlang/cloud-slang
-      status: healthy
-      stars: 240
-      forks: 83
-      last_push: 2026-03-04T10:56:48Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: CloudSlang is a workflow engine to create Docker process automation.
-    - url: https://github.com/clusterdock/clusterdock
-      name: clusterdock/clusterdock
-      status: stale
-      stars: 29
-      forks: 8
-      last_push: 2023-05-16T18:05:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Docker container orchestration to enable the testing of long-running cluster deployments.
-    - url: https://github.com/Dataman-Cloud/crane
-      name: Dataman-Cloud/crane
-      status: stale
-      stars: 748
-      forks: 164
-      last_push: 2023-08-31T09:46:38Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Control plane based on docker built-in swarm [Dataman-Cloud](https://github.com/Dataman-Cloud).
-    - url: https://github.com/docker-flow/docker-flow-swarm-listener
-      name: docker-flow/docker-flow-swarm-listener
-      status: stale
-      stars: 69
-      forks: 50
-      last_push: 2019-05-20T19:40:37Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Docker Flow Swarm Listener project is to listen to Docker Swarm events and send requests when a change occurs. By [docker-flow][docker-flow].
-    - url: https://github.com/Wowu/docker-rollout
-      name: Wowu/docker-rollout
-      status: healthy
-      stars: 3111
-      forks: 93
-      last_push: 2025-07-25T17:57:48Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Zero downtime deployment for Docker Compose services.
-    - url: https://github.com/codeabovelab/haven-platform
-      name: codeabovelab/haven-platform
-      status: stale
-      stars: 297
-      forks: 41
-      last_push: 2018-07-06T11:21:20Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Haven is a simplified container management platform that integrates container, application, cluster, image, and registry managements. By [codeabovelab](https://github.com/codeabovelab).
-    - url: https://github.com/kubernetes/kubernetes
-      name: kubernetes/kubernetes
-      status: healthy
-      stars: 120996
-      forks: 42620
-      last_push: 2026-03-07T08:41:59Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Open source orchestration system for Docker containers by Google.
-    - url: https://github.com/ManageIQ/manageiq
-      name: ManageIQ/manageiq
-      status: healthy
-      stars: 1392
-      forks: 922
-      last_push: 2026-03-05T20:13:05Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Discover, optimize and control your hybrid IT. By [ManageIQ](https://github.com/ManageIQ).
-    - url: https://github.com/apache/mesos
-      name: apache/mesos
-      status: inactive
-      stars: 5364
-      forks: 1669
-      last_push: 2024-08-23T18:59:16Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Resource/Job scheduler for containers, VM's and physical hosts [apache](https://mesos.apache.org/).
-    - url: https://github.com/hashicorp/nomad
-      name: hashicorp/nomad
-      status: healthy
-      stars: 16262
-      forks: 2059
-      last_push: 2026-03-08T09:06:18Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Easily deploy applications at any scale. A Distributed, Highly Available, Datacenter-Aware Scheduler.
-    - url: https://github.com/rancher/rancher
-      name: rancher/rancher
-      status: healthy
-      stars: 25400
-      forks: 3173
-      last_push: 2026-03-06T22:49:23Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: An open source project that provides a complete platform for operating Docker in production.
-    - url: https://github.com/redherd-project/redherd-framework
-      name: redherd-project/redherd-framework
-      status: stale
-      stars: 74
-      forks: 17
-      last_push: 2023-04-25T18:54:33Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: RedHerd is a collaborative and serverless framework for orchestrating a geographically distributed group of assets capable of simulating complex offensive cyberspace operations. By [RedHerdProject](https://github.com/redherd-project).
-    - url: https://github.com/crazy-max/swarm-cronjob
-      name: crazy-max/swarm-cronjob
-      status: healthy
-      stars: 861
-      forks: 74
-      last_push: 2026-03-06T07:02:33Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Orchestration
-      description: Create jobs on a time-based schedule on Swarm by [crazy-max].
-    - url: https://github.com/caprover/caprover
-      name: caprover/caprover
-      status: healthy
-      stars: 14892
-      forks: 966
-      last_push: 2026-01-31T15:42:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: '[Previously known as CaptainDuckDuck] Automated Scalable Webserver Package (automated Docker+nginx) - Heroku on Steroids.'
-    - url: https://github.com/convox/rack
-      name: convox/rack
-      status: healthy
-      stars: 1892
-      forks: 177
-      last_push: 2026-02-12T19:55:53Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: Convox Rack is open source PaaS built on top of expert infrastructure automation and devops best practices.
-    - url: https://github.com/pbertera/dcw
-      name: pbertera/dcw
-      status: stale
-      stars: 17
-      forks: 3
-      last_push: 2017-03-29T07:55:37Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: 'Docker-compose SSH wrapper: a very poor man PaaS, exposing the docker-compose and custom-container commands defined in container labels.'
-    - url: https://github.com/dokku/dokku
-      name: dokku/dokku
-      status: healthy
-      stars: 31896
-      forks: 2022
-      last_push: 2026-03-07T18:31:36Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: Docker powered mini-Heroku that helps you build and manage the lifecycle of applications (originally by [progrium][progrium]).
-    - url: https://github.com/remind101/empire
-      name: remind101/empire
-      status: stale
-      stars: 2681
-      forks: 156
-      last_push: 2023-11-25T17:16:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: A PaaS built on top of Amazon EC2 Container Service (ECS).
-    - url: https://github.com/exoframejs/exoframe
-      name: exoframejs/exoframe
-      status: healthy
-      stars: 1146
-      forks: 59
-      last_push: 2026-02-22T16:24:52Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: A self-hosted tool that allows simple one-command deployments using Docker.
-    - url: https://github.com/teamhephy/workflow
-      name: teamhephy/workflow
-      status: stale
-      stars: 419
-      forks: 36
-      last_push: 2023-09-27T17:30:49Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: Open source PaaS for Kubernetes that adds a developer-friendly layer to any Kubernetes cluster, making it easy to deploy and manage applications. Fork of [Deis Workflow](https://github.com/deis/workflow).
-    - url: https://github.com/krane/krane
-      name: krane/krane
-      status: stale
-      stars: 80
-      forks: 8
-      last_push: 2023-05-11T20:39:00Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: Toolset for managing container workloads on remote servers.
-    - url: https://github.com/nanobox-io/nanobox
-      name: nanobox-io/nanobox
-      status: stale
-      stars: 1625
-      forks: 90
-      last_push: 2019-10-21T20:03:10Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: An application development platform that creates local environments that can then be deployed and scaled in the cloud.
-    - url: https://github.com/tsuru/tsuru
-      name: tsuru/tsuru
-      status: healthy
-      stars: 5259
-      forks: 550
-      last_push: 2026-03-05T03:11:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > PaaS
-      description: Tsuru is an extensible and open source Platform as a Service software.
-    - url: https://github.com/bunkerity/bunkerweb
-      name: bunkerity/bunkerweb
-      status: healthy
-      stars: 10112
-      forks: 568
-      last_push: 2026-03-06T17:15:47Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Open-source and next-gen Web Application Firewall (WAF). By [Bunkerity](https://www.bunkerity.com).
-    - url: https://github.com/lucaslorentz/caddy-docker-proxy
-      name: lucaslorentz/caddy-docker-proxy
-      status: healthy
-      stars: 4315
-      forks: 211
-      last_push: 2026-03-08T07:04:18Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Caddy-based reverse proxy, configured with service or container labels. By [lucaslorentz](https://github.com/lucaslorentz).
-    - url: https://github.com/invzhi/caddy-docker-upstreams
-      name: invzhi/caddy-docker-upstreams
-      status: healthy
-      stars: 36
-      forks: 8
-      last_push: 2025-09-08T05:17:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Docker upstreams module for Caddy, configured with container labels. By [invzhi](https://github.com/invzhi).
-    - url: https://github.com/moonbuggy/docker-dnsmasq-updater
-      name: moonbuggy/docker-dnsmasq-updater
-      status: inactive
-      stars: 35
-      forks: 2
-      last_push: 2025-02-09T00:21:52Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Update a remote dnsmasq server with Docker container hostnames.
-    - url: https://github.com/docker-flow/docker-flow-proxy
-      name: docker-flow/docker-flow-proxy
-      status: healthy
-      stars: 320
-      forks: 189
-      last_push: 2025-12-05T02:29:16Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Reconfigures proxy every time a new service is deployed, or when a service is scaled. By [docker-flow][docker-flow].
-    - url: https://github.com/fabiolb/fabio
-      name: fabiolb/fabio
-      status: healthy
-      stars: 7333
-      forks: 624
-      last_push: 2026-02-23T02:48:11Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: A fast, modern, zero-conf load balancing HTTP(S) router for deploying microservices managed by consul. By [magiconair](https://github.com/magiconair) (Frank Schroeder).
-    - url: https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion
-      name: nginx-proxy/docker-letsencrypt-nginx-proxy-companion
-      status: healthy
-      stars: 7698
-      forks: 834
-      last_push: 2026-03-02T17:04:31Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: A lightweight companion container for the nginx-proxy. It allow the creation/renewal of Let's Encrypt certificates automatically. By [JrCs](https://github.com/JrCs).
-    - url: https://github.com/Yundera/mesh-router
-      name: Yundera/mesh-router
-      status: healthy
-      stars: 8
-      last_push: 2026-03-02T15:37:53Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Free domain(nsl.sh) provider for Docker containers with automatic HTTPS routing. Uses Wireguard VPN to securely route subdomain requests across networks. Ideal for self-hosted NAS and cloud deployments. By [Yundera](https://github.com/Yundera).
-    - url: https://github.com/jc21/nginx-proxy-manager
-      name: jc21/nginx-proxy-manager
-      status: healthy
-      stars: 32001
-      forks: 3639
-      last_push: 2026-03-06T14:15:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: A beautiful web interface for proxying web based services with SSL. By [jc21](https://github.com/jc21).
-    - url: https://github.com/Safe3/openresty-manager
-      name: Safe3/openresty-manager
-      status: healthy
-      stars: 1322
-      forks: 98
-      last_push: 2026-01-25T10:38:42Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: The easiest using, powerful and beautiful OpenResty Manager(Nginx Enhanced Version), open source alternative to OpenResty Edge. By [Safe3](https://github.com/Safe3/).
-    - url: https://github.com/flavioaiello/swarm-router
-      name: flavioaiello/swarm-router
-      status: healthy
-      stars: 73
-      forks: 12
-      last_push: 2025-09-15T06:12:30Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: A «zero config» service name based router for docker swarm mode with a fresh and more secure approach. By [flavioaiello](https://github.com/flavioaiello).
-    - url: https://github.com/containous/traefik
-      name: containous/traefik
-      status: healthy
-      stars: 62086
-      forks: 5865
-      last_push: 2026-03-06T16:16:05Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Reverse Proxy
-      description: Automated reverse proxy and load-balancer for Docker, Mesos, Consul, Etcd... By [EmileVauge](https://github.com/emilevauge).
+      stars: 20722
+      forks: 3921
+      last_push: 2026-05-18T20:51:55Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: An open and reliable container runtime.
     - url: https://github.com/cri-o/cri-o
       name: cri-o/cri-o
       status: healthy
-      stars: 5588
-      forks: 1151
-      last_push: 2026-03-08T00:16:02Z
+      stars: 5613
+      forks: 1173
+      last_push: 2026-05-18T15:14:01Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Runtime
-      description: Open Container Initiative-based implementation of Kubernetes Container Runtime Interface by [cri-o](https://github.com/cri-o).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: Open Container Initiative-based implementation of Kubernetes Container Runtime Interface.
+    - url: https://github.com/google/gvisor
+      name: google/gvisor
+      status: healthy
+      stars: 18339
+      forks: 1605
+      last_push: 2026-05-18T21:19:08Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: Application Kernel for Containers.
     - url: https://github.com/lxc/lxc
       name: lxc/lxc
       status: healthy
-      stars: 5126
-      forks: 1162
-      last_push: 2026-03-02T14:26:30Z
+      stars: 5182
+      forks: 1171
+      last_push: 2026-05-18T15:46:42Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Runtime
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
       description: LXC - Linux Containers.
+    - url: https://github.com/us/mocker
+      name: us/mocker
+      status: healthy
+      stars: 179
+      forks: 4
+      last_push: 2026-05-06T00:07:20Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: Docker-compatible container CLI for macOS, built on Apple's Containerization framework.
     - url: https://github.com/containers/libpod
       name: containers/libpod
       status: healthy
-      stars: 30937
-      forks: 3006
-      last_push: 2026-03-06T15:57:05Z
+      stars: 31722
+      forks: 3113
+      last_push: 2026-05-18T17:26:19Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Runtime
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
       description: Libpod is a library used to create container pods. Home of Podman.
-    - url: https://github.com/brauner/rlxc
-      name: brauner/rlxc
-      status: stale
-      stars: 18
-      forks: 3
-      last_push: 2021-06-30T13:12:28Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Runtime
-      description: LXC binary written in Rust.
+    - url: https://github.com/opencontainers/runc
+      name: opencontainers/runc
+      status: healthy
+      stars: 13233
+      forks: 2281
+      last_push: 2026-05-18T18:13:16Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: CLI tool for spawning and running containers according to the OCI specification.
     - url: https://github.com/opencontainers/runtime-tools
       name: opencontainers/runtime-tools
       status: healthy
-      stars: 473
-      forks: 159
-      last_push: 2025-12-05T00:49:12Z
+      stars: 482
+      forks: 165
+      last_push: 2026-03-16T12:58:33Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Runtime
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
       description: Oci-runtime-tool is a collection of tools for working with the OCI runtime specification.
-    - url: https://github.com/SongStitch/anchor
-      name: SongStitch/anchor
-      status: inactive
-      stars: 24
-      last_push: 2025-01-15T23:09:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-    - url: https://github.com/genuinetools/bane
-      name: genuinetools/bane
-      status: stale
-      stars: 1224
-      forks: 91
-      last_push: 2020-09-17T20:10:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: AppArmor profile generator for Docker containers.
-    - url: https://github.com/dash14/buildcage
-      name: dash14/buildcage
+    - url: https://github.com/youki-dev/youki
+      name: youki-dev/youki
       status: healthy
-      stars: 4
-      last_push: 2026-03-08T16:59:17Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Restricts outbound network access during Docker builds to prevent supply chain attacks, working as a drop-in BuildKit remote driver for Docker Buildx, with ready-to-use GitHub Actions.
-    - url: https://github.com/hectorm/cetusguard
-      name: hectorm/cetusguard
-      status: healthy
-      stars: 82
-      forks: 2
-      last_push: 2026-03-01T11:42:56Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: CetusGuard is a tool that protects the Docker daemon socket by filtering calls to its API endpoints.
-    - url: https://github.com/bridgecrewio/checkov
-      name: bridgecrewio/checkov
-      status: healthy
-      stars: 8510
-      forks: 1307
-      last_push: 2026-03-08T07:40:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Static analysis for infrastructure as code manifests (Terraform, Kubernetes, Cloudformation, Helm, Dockerfile, Kustomize) find security misconfiguration and fix them. By [bridgecrew](https://github.com/bridgecrewio).
-    - url: https://github.com/dev-sec/cis-docker-benchmark
-      name: dev-sec/cis-docker-benchmark
-      status: stale
-      stars: 524
-      forks: 118
-      last_push: 2023-05-02T12:59:10Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: This [InSpec][inspec] compliance profile implement the CIS Docker 1.12.0 Benchmark in an automated way to provide security best-practice tests around Docker daemon and containers in a production environment. By [dev-sec](https://github.com/dev-sec).
-    - url: https://github.com/quay/clair
-      name: quay/clair
-      status: healthy
-      stars: 10940
-      forks: 1195
-      last_push: 2026-03-06T23:17:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Clair is an open source project for the static analysis of vulnerabilities in appc and docker containers. By [coreos][coreos].
-    - url: https://github.com/wolffcatskyy/crowdsec-blocklist-import
-      name: wolffcatskyy/crowdsec-blocklist-import
-      status: healthy
-      stars: 179
-      forks: 4
-      last_push: 2026-03-07T18:44:39Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Aggregates 36 free threat intelligence feeds into 120k+ malicious IPs for CrowdSec bouncers, providing 10-20x more blocks than default lists. By [wolffcatskyy](https://github.com/wolffcatskyy).
-    - url: https://github.com/eliasgranderubio/dagda
-      name: eliasgranderubio/dagda
-      status: stale
-      stars: 1220
-      forks: 169
-      last_push: 2023-05-23T02:03:43Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Dagda is a tool to perform static analysis of known vulnerabilities, trojans, viruses, malware & other malicious threats in docker images/containers and to monitor the docker daemon and running docker containers for detecting anomalous activities. By [eliasgranderubio](https://github.com/eliasgranderubio).
-    - url: https://github.com/deepfence/ThreatMapper
-      name: deepfence/ThreatMapper
-      status: healthy
-      stars: 5235
-      forks: 640
-      last_push: 2026-03-08T03:35:58Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless. By [deepfence][deepfence].
-    - url: https://github.com/docker/docker-bench-security
-      name: docker/docker-bench-security
-      status: inactive
-      stars: 9600
-      forks: 1038
-      last_push: 2024-10-21T07:26:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Script that checks for dozens of common best-practices around deploying Docker containers in production. By [docker][docker].
-    - url: https://github.com/google/docker-explorer
-      name: google/docker-explorer
-      status: inactive
-      stars: 553
-      forks: 45
-      last_push: 2024-10-04T07:44:31Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: A tool to help forensicate offline docker acquisitions.
-    - url: https://github.com/Peco602/dvwassl
-      name: Peco602/dvwassl
-      status: stale
-      stars: 6
-      forks: 4
-      last_push: 2023-04-30T17:03:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: SSL-enabled Damn Vulnerable Web App to test Web Application Firewalls. By [Peco602][peco602].
-    - url: https://github.com/checkmarx/kics
-      name: checkmarx/kics
-      status: healthy
-      stars: 2581
-      forks: 361
-      last_push: 2026-03-06T15:34:55Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: An infrastructure-as-code scanning tool, find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle. Can be extended for additional policies. By [Checkmarx](https://github.com/Checkmarx).
-    - url: https://github.com/theupdateframework/notary
-      name: theupdateframework/notary
-      status: archived
-      stars: 3287
-      forks: 520
-      last_push: 2024-08-07T19:02:32Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: A server and a client for running and interacting with trusted collections. By [TUF](https://github.com/theupdateframework).
-    - url: https://github.com/OpenSCAP/openscap
-      name: OpenSCAP/openscap
-      status: healthy
-      stars: 1676
-      forks: 424
-      last_push: 2026-02-27T12:44:50Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: OpenSCAP provides oscap-docker tool which is used to scan Docker containers and images. By [OpenSCAP](https://github.com/OpenSCAP).
-    - url: https://github.com/dormstern/segspec
-      name: dormstern/segspec
-      status: healthy
-      stars: 15
-      last_push: 2026-02-23T11:39:00Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Extracts network dependencies from Docker Compose, Kubernetes manifests, Helm charts, and other config files to generate Kubernetes NetworkPolicies with evidence tracing. By [dormstern](https://github.com/dormstern).
-    - url: https://github.com/anchore/syft
-      name: anchore/syft
-      status: healthy
-      stars: 8454
-      forks: 779
-      last_push: 2026-03-08T08:12:44Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: CLI tool and library for generating a Software Bill of Materials (SBOM) from container images and filesystems.
-    - url: https://github.com/falcosecurity/falco
-      name: falcosecurity/falco
-      status: healthy
-      stars: 8712
-      forks: 990
-      last_push: 2026-03-02T17:54:20Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Sysdig Falco is an open source container security monitor. It can monitor application, container, host, and network activity and alert on unauthorized activity.
-    - url: https://github.com/aquasecurity/trivy
-      name: aquasecurity/trivy
-      status: healthy
-      stars: 33020
-      forks: 76
-      last_push: 2026-03-06T06:42:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Security
-      description: Aqua Security's open source simple and comprehensive vulnerability scanner for containers (suitable for CI).
-    - url: https://github.com/bytesharky/docker-dns
-      name: bytesharky/docker-dns
-      status: healthy
-      stars: 3
-      forks: 1
-      last_push: 2025-12-26T02:44:43Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Service Discovery
-      description: Lightweight DNS forwarder for Docker containers, resolves container names with custom suffixes (e.g. `.docker`) on the host to simplify service discovery.
-    - url: https://github.com/etcd-io/etcd
-      name: etcd-io/etcd
-      status: healthy
-      stars: 51631
-      forks: 10336
-      last_push: 2026-03-06T20:11:02Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Service Discovery
-      description: Distributed reliable key-value store for the most critical data of a distributed system by [etcd-io](https://github.com/etcd-io) (former part of CoreOS).
-    - url: https://github.com/istio/istio
-      name: istio/istio
-      status: healthy
-      stars: 38089
-      forks: 8260
-      last_push: 2026-03-08T16:55:04Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Service Discovery
-      description: An open platform to connect, manage, and secure microservices.
-    - url: https://github.com/gliderlabs/registrator
-      name: gliderlabs/registrator
-      status: healthy
-      stars: 4675
-      forks: 909
-      last_push: 2025-05-22T04:16:52Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Service Discovery
-      description: Service registry bridge for Docker by [gliderlabs][gliderlabs] and [progrium][progrium].
-    - url: https://github.com/minio/minio
-      name: minio/minio
-      status: archived
-      stars: 60448
-      forks: 7197
-      last_push: 2026-02-12T20:18:51Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Volume Management / Data
-      description: S3 compatible object storage server in Docker containers.
-    - url: https://github.com/Storidge/quick-start
-      name: Storidge/quick-start
-      status: stale
-      stars: 1
-      forks: 1
-      last_push: 2019-09-09T21:42:15Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > Volume Management / Data
-      description: Software-defined Persistent Storage for Kubernetes and Docker Swarm.
-    - url: https://github.com/AbianS/docker-db-manager
-      name: AbianS/docker-db-manager
-      status: healthy
-      stars: 155
-      forks: 5
-      last_push: 2025-11-26T09:24:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Desktop
-      description: Desktop app for managing Docker database containers with visual interface and one-click operations.
-    - url: https://github.com/felixgborrego/simple-docker-ui
-      name: felixgborrego/simple-docker-ui
-      status: inactive
-      stars: 606
-      forks: 96
-      last_push: 2024-09-06T09:31:07Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Desktop
-      description: Built on Electron. By [felixgborrego](https://github.com/felixgborrego/).
-    - url: https://github.com/slonopotamus/stevedore
-      name: slonopotamus/stevedore
-      status: healthy
-      stars: 369
-      forks: 13
-      last_push: 2026-02-27T11:51:20Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Desktop
-      description: Good Docker Desktop replacement for Windows. Both Linux and Windows Containers are supported. [slonopotamus](https://github.com/slonopotamus).
-    - url: https://github.com/jr-k/d4s
-      name: jr-k/d4s
-      status: healthy
-      stars: 55
-      forks: 4
-      last_push: 2026-03-04T21:15:58Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: A fast, keyboard-driven terminal UI to manage Docker containers, Compose stacks, and Swarm services with the ergonomics of K9s.
-    - url: https://github.com/wagoodman/dive
-      name: wagoodman/dive
-      status: healthy
-      stars: 53505
-      forks: 1953
-      last_push: 2025-12-15T17:20:36Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: A tool for exploring each layer in a docker image. By [wagoodman](https://github.com/wagoodman).
-    - url: https://github.com/lirantal/dockly
-      name: lirantal/dockly
-      status: healthy
-      stars: 4014
-      forks: 164
-      last_push: 2026-02-01T19:31:17Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: An interactive shell UI for managing Docker containers.
-    - url: https://github.com/shubh-io/dockmate
-      name: shubh-io/dockmate
-      status: healthy
-      stars: 278
-      forks: 5
-      last_push: 2026-01-14T06:52:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: Lightweight terminal-based Docker and Podman manager with a text-based user interface,.
-    - url: https://github.com/GhostWriters/DockSTARTer
-      name: GhostWriters/DockSTARTer
-      status: healthy
-      stars: 2545
-      forks: 291
-      last_push: 2026-03-01T14:12:50Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: DockSTARTer helps you get started with home server apps running in Docker by [GhostWriters](https://github.com/GhostWriters).
-    - url: https://github.com/durableprogramming/dprs
-      name: durableprogramming/dprs
-      status: healthy
-      stars: 36
-      forks: 1
-      last_push: 2026-03-05T15:59:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: A developer-focused TUI for managing Docker containers with real-time log streaming and container management. Built with Rust. By [durableprogramming](https://github.com/durableprogramming).
-    - url: https://github.com/moncho/dry
-      name: moncho/dry
-      status: healthy
-      stars: 3227
-      forks: 103
-      last_push: 2026-03-08T10:25:15Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: An interactive CLI for Docker containers.
-    - url: https://github.com/ajayd-san/gomanagedocker
-      name: ajayd-san/gomanagedocker
-      status: inactive
-      stars: 632
-      forks: 26
-      last_push: 2024-12-28T07:44:20Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: TUI tool to view and manage your docker objects blazingly fast with sensible keybindings, also supports VIM navigation out of the box.
-    - url: https://github.com/jesseduffield/lazydocker
-      name: jesseduffield/lazydocker
-      status: healthy
-      stars: 50030
-      forks: 1578
-      last_push: 2026-01-17T06:16:20Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library. By [jesseduffield](https://github.com/jesseduffield).
-    - url: https://github.com/Lifailon/lazyjournal
-      name: Lifailon/lazyjournal
-      status: healthy
-      stars: 1175
-      forks: 28
-      last_push: 2026-03-06T14:14:51Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.
-    - url: https://github.com/mrjackwills/oxker
-      name: mrjackwills/oxker
-      status: healthy
-      stars: 1552
-      forks: 43
-      last_push: 2026-02-23T15:18:34Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Terminal UI
-      description: A simple tui to view & control docker containers. Written in [Rust](https://rust-lang.org/), making heavy use of [ratatui](https://github.com/tui-rs-revival/ratatui) & [Bollard](https://github.com/fussybeaver/bollard),.
-    - url: https://github.com/jenssegers/captain
-      name: jenssegers/captain
-      status: stale
-      stars: 244
-      forks: 10
-      last_push: 2022-12-08T07:39:21Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Easily start and stop docker compose projects from any directory. By [jenssegers](https://github.com/jenssegers).
-    - url: https://github.com/Falldog/dcinja
-      name: Falldog/dcinja
-      status: healthy
-      stars: 13
-      forks: 3
-      last_push: 2025-06-26T12:33:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: The powerful and smallest binary size of template engine for docker command line environment. By [Falldog](https://github.com/Falldog).
-    - url: https://github.com/exdx/dcp
-      name: exdx/dcp
-      status: stale
-      stars: 114
-      forks: 3
-      last_push: 2023-07-24T01:09:54Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: A simple tool for copying files from container filesystems. By [exdx](https://github.com/exdx).
-    - url: https://github.com/FabienD/docker-stack
-      name: FabienD/docker-stack
-      status: healthy
-      stars: 22
-      forks: 2
-      last_push: 2026-03-01T10:58:51Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Dctl is a Cli tool that helps developers by allowing them to execute all docker compose commands anywhere in the terminal, and more. By [FabienD](https://github.com/FabienD).
-    - url: https://github.com/s0rg/decompose
-      name: s0rg/decompose
-      status: healthy
-      stars: 126
-      forks: 6
-      last_push: 2025-12-19T20:03:44Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Reverse-engineering tool for docker environments. By [s0rg](https://github.com/s0rg).
-    - url: https://github.com/christian-korneck/docker-pushrm
-      name: christian-korneck/docker-pushrm
-      status: inactive
-      stars: 148
-      forks: 3
-      last_push: 2024-06-10T21:42:09Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: A Docker CLI plugin that lets you push the README.md file from the current directory to Docker Hub. Also supports Quay and Harbor. By [christian-korneck](https://github.com/christian-korneck).
-    - url: https://github.com/lucabello/docker-captain
-      name: lucabello/docker-captain
-      status: healthy
-      stars: 2
-      last_push: 2026-03-07T00:13:26Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: A friendly CLI to manage multiple Docker Compose deployments with style — powered by Typer, Rich, questionary, and sh.
-    - url: https://github.com/mayflower/docker-ls
-      name: mayflower/docker-ls
-      status: archived
-      stars: 456
-      forks: 68
-      last_push: 2023-08-31T06:44:18Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: CLI tools for browsing and manipulating docker registries.
-    - url: https://github.com/howtowhale/dvm
-      name: howtowhale/dvm
-      status: stale
-      stars: 525
-      forks: 50
-      last_push: 2022-03-30T13:23:11Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Docker version manager.
-    - url: https://github.com/iamsoorena/goinside
-      name: iamsoorena/goinside
-      status: stale
-      stars: 30
-      forks: 2
-      last_push: 2020-10-17T20:31:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Get inside a running docker container easily.
-    - url: https://github.com/g31s/Pdocker
-      name: g31s/Pdocker
-      status: stale
-      stars: 7
-      forks: 2
-      last_push: 2021-02-27T06:42:13Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: A simple tool to manage and maintain Docker for personal projects.
-    - url: https://github.com/shiwaforce/poco
-      name: shiwaforce/poco
-      status: healthy
-      stars: 111
-      forks: 6
-      last_push: 2026-02-28T12:31:09Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Proco will help you to organise and manage Docker, Docker-Compose, Kubernetes projects of any complexity using simple YAML config files to shorten the route from finding your project to initialising it in your local environment.
-    - url: https://github.com/JonathonReinhart/scuba
-      name: JonathonReinhart/scuba
-      status: healthy
-      stars: 96
-      forks: 17
-      last_push: 2026-01-26T04:03:05Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Transparently use Docker containers to encapsulate software build environments,.
-    - url: https://github.com/containers/skopeo
-      name: containers/skopeo
-      status: healthy
-      stars: 10538
-      forks: 908
-      last_push: 2026-03-08T00:58:49Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Work with remote images registries - retrieving information, images, signing content.
-    - url: https://github.com/segersniels/supdock
-      name: segersniels/supdock
-      status: healthy
-      stars: 86
-      forks: 3
-      last_push: 2026-02-23T13:29:54Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Allows for slightly more visual usage of Docker with an interactive prompt. By [segersniels](https://github.com/segersniels).
-    - url: https://github.com/qazbnm456/tsaotun
-      name: qazbnm456/tsaotun
-      status: stale
-      stars: 59
-      forks: 3
-      last_push: 2022-10-04T06:53:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > CLI tools
-      description: Python based Assistance for Docker.
-    - url: https://github.com/vutran/dext-docker-registry-plugin
-      name: vutran/dext-docker-registry-plugin
-      status: stale
-      stars: 4
-      forks: 1
-      last_push: 2017-01-10T03:04:36Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Other
-      description: Search the Docker Registry with the Dext smart launcher. By [vutran](https://github.com/vutran).
-    - url: https://github.com/jeroenpeeters/docker-ssh
-      name: jeroenpeeters/docker-ssh
-      status: stale
-      stars: 659
-      forks: 89
-      last_push: 2018-04-11T20:24:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Other
-      description: SSH Server for Docker containers ~ Because every container should be accessible. By [jeroenpeeters](https://github.com/jeroenpeeters).
-    - url: https://github.com/marty90/multidocker
-      name: marty90/multidocker
-      status: stale
-      stars: 56
-      forks: 9
-      last_push: 2018-11-27T15:12:56Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Other
-      description: Create a secure multi-user Docker machine, where each user is segregated into an indepentent container.
-    - url: https://github.com/adrianmo/powerline-docker
-      name: adrianmo/powerline-docker
-      status: stale
-      stars: 61
-      forks: 6
-      last_push: 2017-06-30T09:11:44Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Terminal > Other
-      description: A Powerline segment for showing the status of Docker containers.
-    - url: https://github.com/knrdl/casa
-      name: knrdl/casa
-      status: healthy
-      stars: 84
-      forks: 5
-      last_push: 2026-03-02T14:26:48Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Outsource the administration of a handful of containers to your co-workers,.
-    - url: https://github.com/wrfly/container-web-tty
-      name: wrfly/container-web-tty
-      status: healthy
-      stars: 258
-      forks: 46
-      last_push: 2026-03-02T16:34:06Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Connect your containers via a web-tty [wrfly](https://github.com/wrfly).
-    - url: https://github.com/ProductiveOps/dokemon
-      name: ProductiveOps/dokemon
-      status: stale
-      stars: 759
-      forks: 36
-      last_push: 2024-02-21T10:51:14Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Docker Container Management GUI.
-    - url: https://github.com/klausmeyer/docker-registry-browser
-      name: klausmeyer/docker-registry-browser
-      status: healthy
-      stars: 675
-      forks: 61
-      last_push: 2026-02-21T09:06:10Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Web Interface for the Docker Registry HTTP API v2.
-    - url: https://github.com/mkuchin/docker-registry-web
-      name: mkuchin/docker-registry-web
-      status: stale
-      stars: 548
-      forks: 133
-      last_push: 2022-02-08T08:42:02Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Web UI, authentication service and event recorder for private docker registry v2.
-    - url: https://github.com/dockersamples/docker-swarm-visualizer
-      name: dockersamples/docker-swarm-visualizer
-      status: inactive
-      stars: 3348
-      forks: 596
-      last_push: 2024-10-26T07:12:05Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Visualizes Docker services on a Docker Swarm (for running demos).
-    - url: https://github.com/louislam/dockge
-      name: louislam/dockge
-      status: healthy
-      stars: 22365
-      forks: 707
-      last_push: 2026-01-21T10:51:44Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.
-    - url: https://github.com/mbecker20/komodo
-      name: mbecker20/komodo
-      status: healthy
-      stars: 10494
-      forks: 277
-      last_push: 2026-03-08T14:48:23Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A tool to build and deploy software on many servers.
-    - url: https://github.com/kubevious/kubevious
-      name: kubevious/kubevious
-      status: stale
-      stars: 1692
-      forks: 95
-      last_push: 2024-01-15T18:42:38Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A highly visual web UI for Kubernetes which renders configuration and state in an application centric way.
-    - url: https://github.com/hywax/mafl
-      name: hywax/mafl
-      status: healthy
-      stars: 675
-      forks: 52
-      last_push: 2025-10-26T02:26:26Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Minimalistic flexible homepage.
-    - url: https://github.com/netdata/netdata
-      name: netdata/netdata
-      status: healthy
-      stars: 77993
-      forks: 6360
-      last_push: 2026-03-08T10:17:43Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Real-time performance monitoring.
-    - url: https://github.com/OctoLinker/OctoLinker
-      name: OctoLinker/OctoLinker
-      status: stale
-      stars: 5352
-      forks: 283
-      last_push: 2023-10-02T12:33:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A browser extension for GitHub that makes the image name in a `Dockerfile` clickable and redirect you to the related Docker Hub page.
-    - url: https://github.com/portainer/portainer
-      name: portainer/portainer
-      status: healthy
-      stars: 36781
-      forks: 2787
-      last_push: 2026-03-07T13:14:38Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A lightweight management UI for managing your Docker hosts or Docker Swarm clusters.
-    - url: https://github.com/ozlerhakan/rapid
-      name: ozlerhakan/rapid
-      status: stale
-      stars: 147
-      forks: 24
-      last_push: 2021-09-21T08:44:39Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A simple query dashboard to use Docker Remote API.
-    - url: https://github.com/tobegit3hub/seagull
-      name: tobegit3hub/seagull
-      status: stale
-      stars: 1939
-      forks: 268
-      last_push: 2017-11-22T02:11:23Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Friendly Web UI to monitor docker daemon.
-    - url: https://github.com/swarmpit/swarmpit
-      name: swarmpit/swarmpit
-      status: healthy
-      stars: 3410
-      forks: 312
-      last_push: 2026-03-04T00:04:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Swarmpit provides simple and easy to use interface for your Docker Swarm cluster. You can manage your stacks, services, secrets, volumes, networks etc.
-    - url: https://github.com/cuigh/swirl
-      name: cuigh/swirl
-      status: stale
-      stars: 668
-      forks: 83
-      last_push: 2023-05-16T02:47:48Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Swirl is a web management tool for Docker, focused on swarm cluster By [cuigh](https://github.com/cuigh/).
-    - url: https://github.com/eclipse-theia/theia
-      name: eclipse-theia/theia
-      status: healthy
-      stars: 21393
-      forks: 2801
-      last_push: 2026-03-07T09:12:05Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: Extensible platform to develop full-fledged multi-language Cloud & Desktop IDE-like products with state-of-the-art web technologies.
-    - url: https://github.com/fr4nsys/usulnet
-      name: fr4nsys/usulnet
-      status: healthy
-      stars: 77
-      forks: 3
-      last_push: 2026-02-23T23:00:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Container Operations > User Interface > Web
-      description: A complete and modern Docker management platform designed for sysadmin, devops with enterprise grade tools, cve scanner, ssh, rdp on web and much more. By [fr4nsys](https://github.com/fr4nsys).
-    - url: https://github.com/genuinetools/amicontained
-      name: genuinetools/amicontained
-      status: stale
-      stars: 1073
-      forks: 71
-      last_push: 2020-12-09T04:37:59Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Container introspection tool. Find out what container runtime is being used as well as features available.
-    - url: https://github.com/garywiz/chaperone
-      name: garywiz/chaperone
-      status: stale
-      stars: 179
-      forks: 31
-      last_push: 2020-07-16T21:30:27Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: A single PID1 process designed for docker containers. Does user management, log management, startup, zombie reaping, all in one small package.
-    - url: https://github.com/nicomt/ckron
-      name: nicomt/ckron
-      status: healthy
-      stars: 56
-      forks: 6
-      last_push: 2026-02-15T17:58:14Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: A cron-style job scheduler for docker,.
-    - url: https://github.com/GoogleContainerTools/distroless
-      name: GoogleContainerTools/distroless
-      status: healthy
-      stars: 22329
-      forks: 1360
-      last_push: 2026-03-06T14:09:42Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Language focused docker images, minus the operating system,.
-    - url: https://github.com/gliderlabs/docker-alpine
-      name: gliderlabs/docker-alpine
-      status: stale
-      stars: 5720
-      forks: 530
-      last_push: 2021-04-01T08:02:51Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: A super small Docker base image _(5MB)_ using Alpine Linux.
-    - url: https://github.com/jwilder/docker-gen
-      name: jwilder/docker-gen
-      status: healthy
-      stars: 4620
-      forks: 615
-      last_push: 2026-03-07T14:15:15Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Generate files from docker container meta-data.
-    - url: https://github.com/powerman/dockerize
-      name: powerman/dockerize
-      status: healthy
-      stars: 195
-      forks: 17
-      last_push: 2026-03-05T18:12:32Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Utility to simplify running applications in docker containers by [jwilder][jwilder], [powerman][powerman].
-    - url: https://github.com/tianon/gosu
-      name: tianon/gosu
-      status: healthy
-      stars: 4952
-      forks: 356
-      last_push: 2026-03-04T18:27:37Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Run this specific application as this specific user and get out of the pipeline (entrypoint script tool).
-    - url: https://github.com/sindresorhus/is-docker
-      name: sindresorhus/is-docker
-      status: healthy
-      stars: 233
-      forks: 16
-      last_push: 2025-09-15T21:04:10Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Check if the process is running inside a Docker container.
-    - url: https://github.com/ivanilves/lstags
-      name: ivanilves/lstags
-      status: stale
-      stars: 340
-      forks: 26
-      last_push: 2023-05-11T20:38:37Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Sync Docker images across registries.
-    - url: https://github.com/tarampampam/microcheck
-      name: tarampampam/microcheck
-      status: healthy
-      stars: 130
-      forks: 2
-      last_push: 2026-02-24T19:11:41Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Lightweight health check utilities for Docker containers (75 KB instead of 9.3 MB for httpcheck versus cURL) in pure C - http(s), port checks, and parallel execution are included.
-    - url: https://github.com/mcuadros/ofelia
-      name: mcuadros/ofelia
-      status: healthy
-      stars: 3742
-      forks: 204
-      last_push: 2026-03-08T01:55:37Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-    - url: https://github.com/beyondssl/sparkview-container
-      name: beyondssl/sparkview-container
-      status: healthy
-      stars: 20
-      forks: 2
-      last_push: 2025-09-22T06:59:43Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Access VMs, desktops, servers or applications anytime and from anywhere, without complex and costly client roll-outs or user management.
-    - url: https://github.com/ncopa/su-exec
-      name: ncopa/su-exec
-      status: healthy
-      stars: 1019
-      forks: 103
-      last_push: 2025-10-07T13:49:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: This is a simple tool that will simply execute a program with different privileges. The program will be executed directly and not run as a child, like su and sudo does, which avoids TTY and signal issues. Why reinvent gosu? This does more or less exactly the same thing as gosu but it is only 10kb instead of 1.8MB. By [ncopa](https://github.com/ncopa).
-    - url: https://github.com/theAkito/sue
-      name: theAkito/sue
-      status: stale
-      stars: 13
-      forks: 1
-      last_push: 2022-04-26T21:10:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Executes a program as a user different from the user running sue. This is a maintainable alternative to ncopa/su-exec, which is the better tianon/gosu. This one is far better (higher performance, smaller size), than the original gosu, however it is far easier to maintain, than su-exec, which is written in plain C. Made by [Akito][akito].
-    - url: https://github.com/aptible/supercronic
-      name: aptible/supercronic
-      status: healthy
-      stars: 2391
-      forks: 141
-      last_push: 2026-03-06T13:28:13Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: Crontab-compatible job runner, designed specifically to run in containers.
-    - url: https://github.com/vorakl/TrivialRC
-      name: vorakl/TrivialRC
-      status: stale
-      stars: 32
-      forks: 5
-      last_push: 2023-12-20T00:39:55Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Base Tools
-      description: A minimalistic Runtime Configuration system and process manager for containers [vorakl](https://github.com/vorakl).
+      stars: 7405
+      forks: 432
+      last_push: 2026-05-18T08:25:40Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Engine & Runtime
+      description: Container runtime written in Rust, implementing the OCI runtime specification.
     - url: https://github.com/ansible-community/ansible-bender
       name: ansible-community/ansible-bender
       status: healthy
-      stars: 694
-      forks: 74
+      stars: 695
+      forks: 73
       last_push: 2026-01-07T23:21:32Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: A tool utilising `ansible` and `buildah`.
+    - url: https://github.com/chainguard-dev/apko
+      name: chainguard-dev/apko
+      status: healthy
+      stars: 1612
+      forks: 215
+      last_push: 2026-05-18T00:57:59Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Declarative OCI image builder from apk packages; reproducible by design.
     - url: https://github.com/containers/buildah
       name: containers/buildah
       status: healthy
-      stars: 8662
-      forks: 882
-      last_push: 2026-03-08T17:53:57Z
+      stars: 8789
+      forks: 896
+      last_push: 2026-05-15T22:27:07Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: A tool that facilitates building OCI images.
     - url: https://github.com/moby/buildkit
       name: moby/buildkit
       status: healthy
-      stars: 9817
-      forks: 1379
-      last_push: 2026-03-06T22:37:08Z
+      stars: 9971
+      forks: 1417
+      last_push: 2026-05-18T00:43:44Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit.
+    - url: https://github.com/docker/buildx
+      name: docker/buildx
+      status: healthy
+      stars: 4387
+      forks: 638
+      last_push: 2026-05-14T18:03:13Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Official Docker CLI plugin for multi-platform builds backed by BuildKit.
     - url: https://github.com/cekit/cekit
       name: cekit/cekit
       status: healthy
       stars: 113
       forks: 44
-      last_push: 2026-01-30T15:06:33Z
+      last_push: 2026-03-30T04:08:01Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: A tool used by openshift to build base images using different build engines.
-    - url: https://github.com/mutable/container-factory
-      name: mutable/container-factory
-      status: stale
-      stars: 64
-      forks: 3
-      last_push: 2015-05-06T16:07:53Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Produces Docker images from tarballs of application source code.
-    - url: https://github.com/mdlavin/copy-docker-image
-      name: mdlavin/copy-docker-image
-      status: stale
-      stars: 38
-      forks: 16
-      last_push: 2018-08-29T08:27:20Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Copy a Docker image between registries without a full Docker installation.
-    - url: https://github.com/alibaba/derrick
-      name: alibaba/derrick
-      status: stale
-      stars: 693
-      forks: 109
-      last_push: 2023-03-06T22:40:17Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: A tool help you to automate the generation of Dockerfile and dockerize application by scanning the code. By [alibaba](https://github.com/alibaba).
     - url: https://github.com/orisano/dlayer
       name: orisano/dlayer
       status: healthy
-      stars: 445
+      stars: 446
       forks: 12
-      last_push: 2026-03-02T09:11:34Z
+      last_push: 2026-05-12T12:49:02Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Docker layer analyzer.
     - url: https://github.com/mudler/docker-companion
       name: mudler/docker-companion
@@ -1910,420 +184,1502 @@ entries:
       forks: 9
       last_push: 2025-05-28T08:17:46Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: A command line tool written in Golang to squash and unpack docker images.
-    - url: https://github.com/CtripCloud/docker-make
-      name: CtripCloud/docker-make
-      status: stale
-      stars: 99
-      forks: 20
-      last_push: 2019-11-22T08:32:26Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Build, tag,and push a bunch of related docker images via a single command.
     - url: https://github.com/orf/docker-repack
       name: orf/docker-repack
-      status: healthy
-      stars: 151
+      status: inactive
+      stars: 154
       forks: 3
       last_push: 2025-04-24T06:46:00Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Repacks a Docker image into a smaller, more efficient version that makes it significantly faster to pull. By [orf](https://github.com/orf).
-    - url: https://github.com/bcicen/docker-replay
-      name: bcicen/docker-replay
-      status: stale
-      stars: 203
-      forks: 13
-      last_push: 2018-10-13T13:09:28Z
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Repacks a Docker image into a smaller, more efficient version that makes it significantly faster to pull.
+    - url: https://github.com/earthly/earthly
+      name: earthly/earthly
+      status: healthy
+      stars: 12029
+      forks: 454
+      last_push: 2025-10-23T20:10:46Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Generate `docker run`command and options from running containers. By [bcicen](https://github.com/bcicen).
-    - url: https://github.com/swipely/dockly
-      name: swipely/dockly
-      status: stale
-      stars: 228
-      forks: 10
-      last_push: 2023-02-15T15:26:17Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Dockly is a gem made to ease the pain of packaging an application in Docker.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Containerized build automation with Dockerfile-meets-Makefile syntax.
     - url: https://github.com/utensils/essex
       name: utensils/essex
-      status: healthy
+      status: inactive
       stars: 38
       last_push: 2025-03-18T21:33:36Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: 'Boilerplate for Docker Based Projects: Essex is a CLI utility written in bash to quickly setup clean and consistent Docker projects with Makefile driven workflows. [jamesbrink](https://github.com/jamesbrink).'
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: 'Boilerplate for Docker Based Projects: Essex is a CLI utility written in bash to quickly setup clean and consistent Docker projects with Makefile driven workflows.'
     - url: https://github.com/NVIDIA/hpc-container-maker
       name: NVIDIA/hpc-container-maker
       status: healthy
-      stars: 510
-      forks: 100
-      last_push: 2026-02-19T23:22:06Z
+      stars: 514
+      forks: 102
+      last_push: 2026-05-11T21:40:05Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Generates Dockerfiles from a high level Python recipe, including building blocks for High-Performance Computing components.
     - url: https://github.com/genuinetools/img
       name: genuinetools/img
       status: inactive
-      stars: 3990
-      forks: 234
+      stars: 3986
+      forks: 233
       last_push: 2024-05-19T22:07:07Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder.
-    - url: https://github.com/duedil-ltd/portainer
-      name: duedil-ltd/portainer
-      status: stale
-      stars: 134
-      forks: 16
-      last_push: 2017-02-28T17:15:49Z
+    - url: https://github.com/ko-build/ko
+      name: ko-build/ko
+      status: healthy
+      stars: 8432
+      forks: 442
+      last_push: 2026-05-18T11:43:46Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: Apache Mesos framework for building Docker images.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Build and deploy Go applications as container images without a Dockerfile.
+    - url: https://github.com/nlewo/nix2container
+      name: nlewo/nix2container
+      status: healthy
+      stars: 842
+      forks: 77
+      last_push: 2026-04-06T15:03:51Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: Build OCI images with Nix without `docker load` round-trips.
     - url: https://github.com/cybersecsi/RAUDI
       name: cybersecsi/RAUDI
       status: healthy
       stars: 560
       forks: 34
-      last_push: 2026-03-05T01:57:28Z
+      last_push: 2026-05-18T03:59:35Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: A tool to automatically update (and optionally push to Docker Hub) Docker Images for 3rd party software whenever theres is a new release/update/commit. By [SecSI](https://github.com/cybersecsi).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
+      description: A tool to automatically update (and optionally push to Docker Hub) Docker Images for 3rd party software whenever theres is a new release/update/commit.
     - url: https://github.com/lavie/runlike
       name: lavie/runlike
       status: healthy
-      stars: 2919
-      forks: 163
-      last_push: 2025-12-04T12:36:39Z
+      stars: 2926
+      forks: 167
+      last_push: 2026-04-27T14:03:20Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Generate `docker run`command and options from running containers.
-    - url: https://github.com/theAkito/userdef
-      name: theAkito/userdef
-      status: stale
-      stars: 11
-      last_push: 2023-10-14T20:34:12Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: An advanced `adduser` for your Alpine based Docker images. Made by [Akito][akito].
     - url: https://github.com/P3GLEG/Whaler
       name: P3GLEG/Whaler
       status: healthy
       stars: 1185
-      forks: 101
-      last_push: 2025-09-17T03:56:52Z
+      forks: 103
+      last_push: 2026-04-08T19:28:12Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Builder
       description: Program to reverse Docker images into Dockerfiles.
-    - url: https://github.com/Gueils/whales
-      name: Gueils/whales
-      status: stale
-      stars: 391
-      forks: 20
-      last_push: 2019-05-27T13:20:14Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Builder
-      description: A tool to automatically dockerize your applications.
-    - url: https://github.com/garywiz/chaperone-docker
-      name: garywiz/chaperone-docker
-      status: stale
-      stars: 66
-      forks: 11
-      last_push: 2018-10-05T07:48:36Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Dockerfile
-      description: A set of images using the Chaperone process manager, including a lean Alpine image, LAMP, LEMP, and bare-bones base kits.
-    - url: https://github.com/patrickhoefler/dockerfilegraph
-      name: patrickhoefler/dockerfilegraph
+    - url: https://github.com/chainguard-images/images
+      name: chainguard-images/images
       status: healthy
-      stars: 255
-      forks: 17
-      last_push: 2026-03-08T00:49:58Z
+      stars: 668
+      forks: 175
+      last_push: 2026-05-18T20:50:10Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Dockerfile
-      description: Visualize your multi-stage Dockerfiles. By [PatrickHoefler](https://github.com/patrickhoefler).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Base Images
+      description: Minimal, signed, SBOM-attested container images built on Wolfi.
+    - url: https://github.com/GoogleContainerTools/distroless
+      name: GoogleContainerTools/distroless
+      status: healthy
+      stars: 22631
+      forks: 1389
+      last_push: 2026-05-18T20:57:36Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Base Images
+      description: Language focused docker images, minus the operating system.
+    - url: https://github.com/chainguard-dev/melange
+      name: chainguard-dev/melange
+      status: healthy
+      stars: 598
+      forks: 170
+      last_push: 2026-05-18T00:48:12Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Base Images
+      description: Build apk packages from declarative YAML for use with apko.
+    - url: https://github.com/wolfi-dev/os
+      name: wolfi-dev/os
+      status: healthy
+      stars: 1217
+      forks: 433
+      last_push: 2026-05-18T15:10:52Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Base Images
+      description: Undistro Linux designed for containers; glibc-based, signed, daily SBOMs.
     - url: https://github.com/Dockershelf/dockershelf
       name: Dockershelf/dockershelf
       status: healthy
-      stars: 97
+      stars: 96
       forks: 13
-      last_push: 2026-03-05T01:03:36Z
+      last_push: 2026-04-30T01:03:40Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Dockerfile
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Dockerfile
       description: A repository that serves as a collector for docker recipes that are universal, efficient and slim. Images are updated, tested and published daily via a Travis cron job.
     - url: https://github.com/deckrun/dockadvisor
       name: deckrun/dockadvisor
       status: healthy
-      stars: 186
-      forks: 6
+      stars: 203
+      forks: 7
       last_push: 2026-01-12T09:26:02Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Linter
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Linter
       description: Lightweight Dockerfile linter with 60+ rules, quality scoring, and security checks.
     - url: https://github.com/wemake-services/docker-image-size-limit
       name: wemake-services/docker-image-size-limit
       status: healthy
-      stars: 130
+      stars: 131
       forks: 5
-      last_push: 2026-03-06T23:18:34Z
+      last_push: 2026-05-15T07:17:04Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Linter
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Linter
       description: A tool to keep an eye on your docker images size.
-    - url: https://github.com/buddy-works/dockerfile-linter
-      name: buddy-works/dockerfile-linter
-      status: stale
-      stars: 46
-      forks: 3
-      last_push: 2023-03-04T05:06:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Linter
-      description: The linter lets you verify Dockerfile syntax to make sure it follows the best practices for building efficient Docker images.
-    - url: https://github.com/replicatedhq/dockerfilelint
-      name: replicatedhq/dockerfilelint
-      status: stale
-      stars: 1029
-      forks: 83
-      last_push: 2023-09-27T20:58:01Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Linter
-      description: An opinionated Dockerfile linter.
     - url: https://github.com/hadolint/hadolint
       name: hadolint/hadolint
       status: healthy
-      stars: 11985
-      forks: 487
-      last_push: 2026-03-02T08:58:07Z
+      stars: 12141
+      forks: 492
+      last_push: 2026-05-13T10:19:09Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Linter
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Building Images > Linter
       description: A Dockerfile linter that checks for best practices, common mistakes, and is also able to lint any bash written in `RUN` instructions;.
-    - url: https://github.com/RedCoolBeans/cargos-buildroot
-      name: RedCoolBeans/cargos-buildroot
-      status: stale
-      stars: 11
-      forks: 2
-      last_push: 2017-04-02T14:59:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
-      description: A bare essential OS for running the Docker Engine on bare metal or Cloud. By [RedCoolBeans](https://github.com/RedCoolBeans).
-    - url: https://github.com/hcguersoy/cleanreg
-      name: hcguersoy/cleanreg
-      status: stale
-      stars: 59
-      forks: 18
-      last_push: 2022-09-03T17:43:40Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
-      description: A small tool to delete image manifests from a Docker Registry implementing the API v2, dereferencing them for the GC.
-    - url: https://github.com/netvarun/docket
-      name: netvarun/docket
-      status: stale
-      stars: 709
-      forks: 33
-      last_push: 2020-09-02T02:35:17Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
-      description: Custom docker registry that allows for lightning fast deploys through bittorrent.
     - url: https://github.com/dragonflyoss/Dragonfly2
       name: dragonflyoss/Dragonfly2
       status: healthy
-      stars: 3070
-      forks: 377
-      last_push: 2026-03-05T12:44:54Z
+      stars: 3167
+      forks: 397
+      last_push: 2026-05-15T03:49:27Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
       description: Provide efficient, stable and secure file distribution and image acceleration based on p2p technology.
+    - url: https://github.com/imjasonh/kontain.me
+      name: imjasonh/kontain.me
+      status: healthy
+      stars: 240
+      forks: 13
+      last_push: 2026-05-15T14:30:38Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
+      description: On-demand container image registry that builds and serves images when they are pulled.
     - url: https://github.com/uber/kraken
       name: uber/kraken
       status: healthy
-      stars: 6659
-      forks: 468
-      last_push: 2026-03-05T13:24:04Z
+      stars: 6690
+      forks: 473
+      last_push: 2026-05-18T10:12:54Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
       description: Uber's Highly scalable P2P docker registry, capable of distributing TBs of data in seconds.
+    - url: https://github.com/getnora-io/nora
+      name: getnora-io/nora
+      status: healthy
+      stars: 167
+      forks: 11
+      last_push: 2026-05-18T20:23:30Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
+      description: Lightweight multi-protocol artifact registry supporting Docker, Maven, npm, Cargo and PyPI in a single 32MB binary. Pull-through cache, Web UI, Prometheus metrics, RBAC auth.
     - url: https://github.com/jhstatewide/nscr
       name: jhstatewide/nscr
       status: healthy
       stars: 1
       last_push: 2025-10-27T14:37:18Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
       description: A light-weight, self-contained container registry that's easy to run and maintain.
     - url: https://github.com/inmagik/registryo
       name: inmagik/registryo
       status: healthy
       stars: 15
       last_push: 2025-12-17T10:20:47Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry
       description: UI and token based authentication server for onpremise docker registry.
-    - url: https://github.com/noteed/rescoyl
-      name: noteed/rescoyl
-      status: stale
-      stars: 18
+    - url: https://github.com/google/go-containerregistry
+      name: google/go-containerregistry
+      status: healthy
+      stars: 3872
+      forks: 641
+      last_push: 2026-05-18T19:37:36Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry CLI
+      description: Go library and CLI tools (`crane`, `gcrane`, `registry`) for working with container registries.
+    - url: https://github.com/oras-project/oras
+      name: oras-project/oras
+      status: healthy
+      stars: 2269
+      forks: 234
+      last_push: 2026-05-18T13:49:56Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry CLI
+      description: Push and pull arbitrary OCI artifacts to and from any OCI registry.
+    - url: https://github.com/regclient/regclient
+      name: regclient/regclient
+      status: healthy
+      stars: 1838
+      forks: 122
+      last_push: 2026-05-13T19:07:01Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry CLI
+      description: Daemonless registry client; copy, inspect, modify, and sign OCI images.
+    - url: https://github.com/containers/skopeo
+      name: containers/skopeo
+      status: healthy
+      stars: 10877
+      forks: 921
+      last_push: 2026-05-18T14:17:31Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Registry CLI
+      description: 'Work with remote image registries: retrieve information, copy images, sign content.'
+    - url: https://github.com/SongStitch/anchor
+      name: SongStitch/anchor
+      status: inactive
+      stars: 24
+      last_push: 2025-01-15T23:09:06Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+    - url: https://github.com/quay/clair
+      name: quay/clair
+      status: healthy
+      stars: 10979
+      forks: 1208
+      last_push: 2026-05-13T17:02:51Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: Clair is an open source project for the static analysis of vulnerabilities in appc and docker containers.
+    - url: https://github.com/docker/scout-cli
+      name: docker/scout-cli
+      status: healthy
+      stars: 445
+      forks: 128
+      last_push: 2026-04-08T08:04:21Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: Official Docker CLI for SBOM generation, vulnerability analysis, and policy evaluation.
+    - url: https://github.com/anchore/grype
+      name: anchore/grype
+      status: healthy
+      stars: 12228
+      forks: 795
+      last_push: 2026-05-18T19:20:53Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: A vulnerability scanner for container images, filesystems and SBOMs.
+    - url: https://github.com/OpenSCAP/openscap
+      name: OpenSCAP/openscap
+      status: healthy
+      stars: 1717
+      forks: 433
+      last_push: 2026-05-14T13:22:33Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: OpenSCAP provides oscap-docker tool which is used to scan Docker containers and images.
+    - url: https://github.com/deadnews/pindock
+      name: deadnews/pindock
+      status: healthy
+      stars: 2
+      last_push: 2026-05-07T11:07:59Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: Pin and update Docker image digests in Dockerfiles and compose files.
+    - url: https://github.com/anchore/syft
+      name: anchore/syft
+      status: healthy
+      stars: 8952
+      forks: 860
+      last_push: 2026-05-18T19:01:40Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: CLI tool and library for generating a Software Bill of Materials (SBOM) from container images and filesystems.
+    - url: https://github.com/aquasecurity/trivy
+      name: aquasecurity/trivy
+      status: healthy
+      stars: 35038
+      forks: 379
+      last_push: 2026-05-18T13:26:17Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Image Scanning & SBOM
+      description: Aqua Security's open source simple and comprehensive vulnerability scanner for containers (suitable for CI).
+    - url: https://github.com/sigstore/cosign
+      name: sigstore/cosign
+      status: healthy
+      stars: 5925
+      forks: 734
+      last_push: 2026-05-18T18:53:10Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Supply Chain
+      description: Container signing, verification, and transparency log for OCI artifacts.
+    - url: https://github.com/in-toto/in-toto
+      name: in-toto/in-toto
+      status: healthy
+      stars: 999
+      forks: 155
+      last_push: 2026-05-05T00:53:21Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Supply Chain
+      description: Framework for supply chain attestations; underpins SLSA and cosign provenance.
+    - url: https://github.com/sigstore/policy-controller
+      name: sigstore/policy-controller
+      status: healthy
+      stars: 172
+      forks: 69
+      last_push: 2026-05-08T23:10:07Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Supply Chain
+      description: Kubernetes admission controller enforcing cosign signatures on container images.
+    - url: https://github.com/in-toto/witness
+      name: in-toto/witness
+      status: healthy
+      stars: 530
+      forks: 77
+      last_push: 2026-05-18T19:19:00Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Image Lifecycle > Supply Chain
+      description: Generate and verify in-toto attestations across the build pipeline.
+    - url: https://github.com/magicmark/composerize
+      name: magicmark/composerize
+      status: healthy
+      stars: 3738
+      forks: 253
+      last_push: 2026-05-17T14:35:15Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Composition
+      description: Convert docker run commands into docker-compose files.
+    - url: https://github.com/ctk-hq/ctk
+      name: ctk-hq/ctk
+      status: healthy
+      stars: 300
+      forks: 27
+      last_push: 2026-02-15T22:53:00Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Composition
+      description: Visual composer for container based workloads.
+    - url: https://github.com/kubernetes/kompose
+      name: kubernetes/kompose
+      status: healthy
+      stars: 10525
+      forks: 798
+      last_push: 2026-04-16T14:23:39Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Composition
+      description: Go from Docker Compose to Kubernetes.
+    - url: https://github.com/ihucos/plash
+      name: ihucos/plash
+      status: inactive
+      stars: 384
+      forks: 15
+      last_push: 2025-03-20T15:47:21Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Composition
+      description: A container run and build engine - runs inside docker.
+    - url: https://github.com/containers/podman-compose
+      name: containers/podman-compose
+      status: healthy
+      stars: 6074
+      forks: 596
+      last_push: 2026-05-04T20:34:25Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Composition
+      description: A script to run docker-compose.yml using podman.
+    - url: https://github.com/CloudSlang/cloud-slang
+      name: CloudSlang/cloud-slang
+      status: healthy
+      stars: 241
+      forks: 84
+      last_push: 2026-05-14T12:30:42Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: CloudSlang is a workflow engine to create Docker process automation.
+    - url: https://github.com/Wowu/docker-rollout
+      name: Wowu/docker-rollout
+      status: healthy
+      stars: 3213
+      forks: 95
+      last_push: 2026-04-02T21:01:55Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: Zero downtime deployment for Docker Compose services.
+    - url: https://github.com/kubernetes/kubernetes
+      name: kubernetes/kubernetes
+      status: healthy
+      stars: 122338
+      forks: 43096
+      last_push: 2026-05-18T16:14:02Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: Open source orchestration system for Docker containers by Google.
+    - url: https://github.com/apache/mesos
+      name: apache/mesos
+      status: healthy
+      stars: 5370
+      forks: 1666
+      last_push: 2026-05-15T22:22:50Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: Resource/Job scheduler for containers, VM's and physical hosts.
+    - url: https://github.com/hashicorp/nomad
+      name: hashicorp/nomad
+      status: healthy
+      stars: 16509
+      forks: 2088
+      last_push: 2026-05-18T19:55:35Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: Easily deploy applications at any scale. A Distributed, Highly Available, Datacenter-Aware Scheduler.
+    - url: https://github.com/rancher/rancher
+      name: rancher/rancher
+      status: healthy
+      stars: 25585
+      forks: 3194
+      last_push: 2026-05-18T21:09:51Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: An open source project that provides a complete platform for operating Docker in production.
+    - url: https://github.com/crazy-max/swarm-cronjob
+      name: crazy-max/swarm-cronjob
+      status: healthy
+      stars: 872
+      forks: 74
+      last_push: 2026-05-18T19:04:41Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Orchestration
+      description: Create jobs on a time-based schedule on Swarm.
+    - url: https://github.com/caprover/caprover
+      name: caprover/caprover
+      status: healthy
+      stars: 15028
+      forks: 976
+      last_push: 2026-05-14T18:12:25Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: '[Previously known as CaptainDuckDuck] Automated Scalable Webserver Package (automated Docker+nginx) - Heroku on Steroids.'
+    - url: https://github.com/convox/rack
+      name: convox/rack
+      status: healthy
+      stars: 1892
+      forks: 176
+      last_push: 2026-04-21T23:26:52Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Convox Rack is open source PaaS built on top of expert infrastructure automation and devops best practices.
+    - url: https://github.com/deploystackio/docker-to-iac
+      name: deploystackio/docker-to-iac
+      status: healthy
+      stars: 21
+      last_push: 2026-03-20T05:57:15Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Translate docker run and commit into Infrastructure as Code templates for AWS, Render.com and DigitalOcean.
+    - url: https://github.com/dokku/dokku
+      name: dokku/dokku
+      status: healthy
+      stars: 31887
+      forks: 2034
+      last_push: 2026-05-17T06:58:54Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Docker powered mini-Heroku that helps you build and manage the lifecycle of applications.
+    - url: https://github.com/exoframejs/exoframe
+      name: exoframejs/exoframe
+      status: healthy
+      stars: 1151
+      forks: 59
+      last_push: 2026-05-11T20:05:06Z
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: A self-hosted tool that allows simple one-command deployments using Docker.
+    - url: https://github.com/grafeas/grafeas
+      name: grafeas/grafeas
+      status: healthy
+      stars: 1564
+      forks: 307
+      last_push: 2026-05-08T23:32:27Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: A common API for metadata about containers, from image and build details to security vulnerabilities.
+    - url: https://github.com/LombardiDaniel/swarm-ansible
+      name: LombardiDaniel/swarm-ansible
+      status: healthy
+      stars: 57
       forks: 4
-      last_push: 2017-04-08T19:17:24Z
+      last_push: 2026-03-10T23:06:30Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Docker Images > Registry
-      description: Private Docker registry (free and open source).
-    - url: https://github.com/instacart/ahab
-      name: instacart/ahab
-      status: stale
-      stars: 137
+      checked_at: 2026-05-18T21:29:20.484404Z
+    - url: https://github.com/hansehe/SwarmManagement
+      name: hansehe/SwarmManagement
+      status: healthy
+      stars: 21
+      forks: 1
+      last_push: 2026-05-05T11:10:29Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Swarm Management is a python application, installed with pip. The application makes it easy to manage a Docker Swarm by configuring a single yaml file describing which stacks to deploy, and which networks, configs or secrets to create.
+    - url: https://github.com/tsuru/tsuru
+      name: tsuru/tsuru
+      status: healthy
+      stars: 5277
+      forks: 553
+      last_push: 2026-05-18T21:07:41Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Tsuru is an extensible and open source Platform as a Service software.
+    - url: https://github.com/werf/werf
+      name: werf/werf
+      status: healthy
+      stars: 4685
+      forks: 236
+      last_push: 2026-05-18T17:59:40Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Deployment & Platforms
+      description: Werf is a CI/CD tool for building Docker images efficiently and deploying them to Kubernetes using GitOps.
+    - url: https://github.com/Yelp/docker-custodian
+      name: Yelp/docker-custodian
+      status: healthy
+      stars: 373
+      forks: 49
+      last_push: 2026-04-02T17:05:49Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Garbage Collection
+      description: Keep docker hosts tidy.
+    - url: https://github.com/stepchowfun/docuum
+      name: stepchowfun/docuum
+      status: healthy
+      stars: 693
+      forks: 42
+      last_push: 2026-04-26T19:47:34Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Running Containers > Garbage Collection
+      description: Least recently used (LRU) eviction of Docker images.
+    - url: https://github.com/bytesharky/docker-dns
+      name: bytesharky/docker-dns
+      status: healthy
+      stars: 4
+      forks: 1
+      last_push: 2025-12-26T02:44:43Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Networking
+      description: Lightweight DNS forwarder for Docker containers, resolves container names with custom suffixes (e.g. `.docker`) on the host to simplify service discovery.
+    - url: https://github.com/coreos/flannel
+      name: coreos/flannel
+      status: healthy
+      stars: 9454
+      forks: 2892
+      last_push: 2026-05-18T14:49:07Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+    - url: https://github.com/nicolaka/netshoot
+      name: nicolaka/netshoot
+      status: healthy
+      stars: 10684
+      forks: 1087
+      last_push: 2026-04-16T16:42:57Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Networking
+      description: The netshoot container has a powerful set of networking tools to help troubleshoot Docker networking issues.
+    - url: https://github.com/jpetazzo/pipework
+      name: jpetazzo/pipework
+      status: inactive
+      stars: 4252
+      forks: 725
+      last_push: 2024-11-04T17:31:57Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Networking
+      description: Software-Defined Networking for Linux Containers, Pipework works with "plain" LXC containers, and with the awesome Docker.
+    - url: https://github.com/gliderlabs/registrator
+      name: gliderlabs/registrator
+      status: healthy
+      stars: 4675
+      forks: 904
+      last_push: 2025-05-22T04:16:52Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Networking
+      description: Service registry bridge for Docker.
+    - url: https://github.com/bunkerity/bunkerweb
+      name: bunkerity/bunkerweb
+      status: healthy
+      stars: 10501
+      forks: 606
+      last_push: 2026-05-18T20:54:11Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Open-source and next-gen Web Application Firewall (WAF).
+    - url: https://github.com/lucaslorentz/caddy-docker-proxy
+      name: lucaslorentz/caddy-docker-proxy
+      status: healthy
+      stars: 4476
+      forks: 216
+      last_push: 2026-05-12T03:10:39Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Caddy-based reverse proxy, configured with service or container labels.
+    - url: https://github.com/invzhi/caddy-docker-upstreams
+      name: invzhi/caddy-docker-upstreams
+      status: healthy
+      stars: 35
+      forks: 8
+      last_push: 2025-09-08T05:17:01Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Docker upstreams module for Caddy, configured with container labels.
+    - url: https://github.com/moonbuggy/docker-dnsmasq-updater
+      name: moonbuggy/docker-dnsmasq-updater
+      status: inactive
+      stars: 34
+      forks: 2
+      last_push: 2025-02-09T00:21:52Z
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Update a remote dnsmasq server with Docker container hostnames.
+    - url: https://github.com/docker-flow/docker-flow-proxy
+      name: docker-flow/docker-flow-proxy
+      status: healthy
+      stars: 318
+      forks: 186
+      last_push: 2025-12-05T02:29:16Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Reconfigures proxy every time a new service is deployed, or when a service is scaled.
+    - url: https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion
+      name: nginx-proxy/docker-letsencrypt-nginx-proxy-companion
+      status: healthy
+      stars: 7703
+      forks: 831
+      last_push: 2026-05-07T11:30:30Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: A lightweight companion container for the nginx-proxy. It allow the creation/renewal of Let's Encrypt certificates automatically.
+    - url: https://github.com/Yundera/mesh-router
+      name: Yundera/mesh-router
+      status: healthy
+      stars: 12
+      forks: 1
+      last_push: 2026-03-02T15:37:53Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Free domain(nsl.sh) provider for Docker containers with automatic HTTPS routing. Uses Wireguard VPN to securely route subdomain requests across networks. Ideal for self-hosted NAS and cloud deployments.
+    - url: https://github.com/jc21/nginx-proxy-manager
+      name: jc21/nginx-proxy-manager
+      status: healthy
+      stars: 32862
+      forks: 3743
+      last_push: 2026-05-18T06:55:45Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: A beautiful web interface for proxying web based services with SSL.
+    - url: https://github.com/Safe3/openresty-manager
+      name: Safe3/openresty-manager
+      status: healthy
+      stars: 1383
+      forks: 106
+      last_push: 2026-05-17T13:30:56Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: The easiest using, powerful and beautiful OpenResty Manager(Nginx Enhanced Version), open source alternative to OpenResty Edge.
+    - url: https://github.com/flavioaiello/swarm-router
+      name: flavioaiello/swarm-router
+      status: healthy
+      stars: 75
+      forks: 12
+      last_push: 2025-09-15T06:12:30Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: A zero config service name based router for docker swarm mode with a fresh and more secure approach.
+    - url: https://github.com/containous/traefik
+      name: containous/traefik
+      status: healthy
+      stars: 63213
+      forks: 6001
+      last_push: 2026-05-18T14:02:06Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Networking & Proxies > Reverse Proxy
+      description: Automated reverse proxy and load-balancer for Docker, Mesos, Consul, Etcd.
+    - url: https://github.com/resulgg/label-backup
+      name: resulgg/label-backup
+      status: healthy
+      stars: 22
+      forks: 2
+      last_push: 2025-10-27T12:29:36Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Storage & Data
+      description: A lightweight, Docker-aware backup agent that automatically discovers and backs up containerized databases (PostgreSQL, MySQL, MongoDB, Redis) based on Docker labels. Supports local storage and S3-compatible destinations with flexible scheduling via cron expressions.
+    - url: https://github.com/jaldertech/adrg
+      name: jaldertech/adrg
+      status: healthy
+      stars: 9
+      last_push: 2026-03-07T21:00:08Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Dynamic Docker resource governor using cgroups v2 to manage system load.
+    - url: https://github.com/Appdynamics/docker-monitoring-extension
+      name: Appdynamics/docker-monitoring-extension
+      status: inactive
+      stars: 5
+      forks: 6
+      last_push: 2024-10-02T10:48:59Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Docker Monitoring extension gathers metrics from the Docker Remote API, either using Unix Socket or TCP.
+    - url: https://github.com/willfarrell/docker-autoheal
+      name: willfarrell/docker-autoheal
+      status: healthy
+      stars: 1904
+      forks: 258
+      last_push: 2025-09-09T16:33:25Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Monitor and restart unhealthy docker containers automatically.
+    - url: https://github.com/google/cadvisor
+      name: google/cadvisor
+      status: healthy
+      stars: 19132
+      forks: 2465
+      last_push: 2026-05-14T15:14:42Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Analyzes resource usage and performance characteristics of running containers.
+    - url: https://github.com/zorak1103/dlia
+      name: zorak1103/dlia
+      status: healthy
+      stars: 3
+      last_push: 2026-05-12T05:41:14Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: DLIA is an AI-powered Docker log monitoring agent that uses Large Language Models (LLMs) to intelligently analyze container logs, detect anomalies, and provide contextual insights over time.
+    - url: https://github.com/dlepaux/docker-exporter
+      name: dlepaux/docker-exporter
+      status: healthy
+      stars: 1
+      last_push: 2026-05-15T05:47:25Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Lightweight Prometheus exporter for Docker container metrics written in Rust. Correct cgroup v2 memory working set on ARM64 (Raspberry Pi 5), runs non-root with a read-only socket, ~7 MiB idle RAM.
+    - url: https://github.com/Will-Luck/Docker-Sentinel
+      name: Will-Luck/Docker-Sentinel
+      status: healthy
+      stars: 18
+      forks: 2
+      last_push: 2026-05-15T22:53:52Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Automated container updates with per-container policies, rollback safety, and a real-time web dashboard.
+    - url: https://github.com/deep-on/dockprobe
+      name: deep-on/dockprobe
+      status: healthy
+      stars: 14
+      last_push: 2026-04-11T08:07:46Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Lightweight Docker monitoring dashboard in a single container. Real-time metrics, 6 anomaly detection rules, Telegram alerts, and 16 automated security scans. Zero config, ~50MB RAM.
+    - url: https://github.com/stefanprodan/dockprom
+      name: stefanprodan/dockprom
+      status: healthy
+      stars: 6510
+      forks: 1759
+      last_push: 2026-03-06T05:28:07Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Docker hosts and containers monitoring with Prometheus, Grafana, cAdvisor, NodeExporter and AlertManager.
+    - url: https://github.com/amerkurev/doku
+      name: amerkurev/doku
+      status: healthy
+      stars: 416
+      forks: 18
+      last_push: 2025-12-26T09:13:21Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Doku is a simple web-based application that allows you to monitor Docker disk usage.
+    - url: https://github.com/CodesWhat/drydock
+      name: CodesWhat/drydock
+      status: healthy
+      stars: 198
+      forks: 10
+      last_push: 2026-05-18T20:53:37Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Container update monitoring with web dashboard, 23 registry providers, 20 notification triggers, and distributed agent architecture.
+    - url: https://github.com/kolapsis/maintenant
+      name: kolapsis/maintenant
+      status: healthy
+      stars: 271
+      forks: 12
+      last_push: 2026-05-18T10:12:51Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: Self-discovering infrastructure monitoring for Docker and Kubernetes. Auto-detects containers via labels, with endpoint monitoring, heartbeats, TLS certificates, resource metrics, update intelligence, and a built-in status page. Single binary with embedded SPA.
+    - url: https://github.com/codeofmario/wiremap
+      name: codeofmario/wiremap
+      status: healthy
+      stars: 3
+      forks: 1
+      last_push: 2026-05-02T14:16:22Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Observability
+      description: A self-hosted visual Docker network topology explorer with real-time log streaming, live stats, embedded terminal, and container inspection.
+    - url: https://github.com/dash14/buildcage
+      name: dash14/buildcage
+      status: healthy
+      stars: 4
+      last_push: 2026-05-17T20:24:03Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Restricts outbound network access during Docker builds to prevent supply chain attacks, working as a drop-in BuildKit remote driver for Docker Buildx, with ready-to-use GitHub Actions.
+    - url: https://github.com/hectorm/cetusguard
+      name: hectorm/cetusguard
+      status: healthy
+      stars: 85
+      forks: 2
+      last_push: 2026-04-01T13:49:35Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: CetusGuard is a tool that protects the Docker daemon socket by filtering calls to its API endpoints.
+    - url: https://github.com/bridgecrewio/checkov
+      name: bridgecrewio/checkov
+      status: healthy
+      stars: 8720
+      forks: 1336
+      last_push: 2026-05-14T23:16:40Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Static analysis for infrastructure as code manifests (Terraform, Kubernetes, Cloudformation, Helm, Dockerfile, Kustomize) find security misconfiguration and fix them.
+    - url: https://github.com/google/container-explorer
+      name: google/container-explorer
+      status: healthy
+      stars: 96
+      forks: 10
+      last_push: 2026-05-05T12:36:48Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Forensic utility to explore Docker and containerd container details from mounted disk images.
+    - url: https://github.com/deepfence/ThreatMapper
+      name: deepfence/ThreatMapper
+      status: healthy
+      stars: 5268
+      forks: 635
+      last_push: 2026-05-13T07:51:41Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
+    - url: https://github.com/us/den
+      name: us/den
+      status: healthy
+      stars: 7
+      forks: 1
+      last_push: 2026-03-15T14:07:59Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Self-hosted sandbox runtime for AI agents with Docker containers, security hardening, REST API and WebSocket support.
+    - url: https://github.com/docker/docker-bench-security
+      name: docker/docker-bench-security
+      status: inactive
+      stars: 9636
+      forks: 1038
+      last_push: 2024-10-21T07:26:06Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Script that checks for dozens of common best-practices around deploying Docker containers in production.
+    - url: https://github.com/Tecnativa/docker-socket-proxy
+      name: Tecnativa/docker-socket-proxy
+      status: healthy
+      stars: 2506
+      forks: 198
+      last_push: 2026-02-25T08:15:08Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: HAProxy-based fine-grained filter for the Docker API socket; widely used to expose a restricted socket to reverse proxies and homelab stacks.
+    - url: https://github.com/checkmarx/kics
+      name: checkmarx/kics
+      status: healthy
+      stars: 2634
+      forks: 367
+      last_push: 2026-04-22T14:47:48Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: An infrastructure-as-code scanning tool, find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle. Can be extended for additional policies.
+    - url: https://github.com/dormstern/segspec
+      name: dormstern/segspec
+      status: healthy
+      stars: 15
+      last_push: 2026-05-06T07:36:28Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Extracts network dependencies from Docker Compose, Kubernetes manifests, Helm charts, and other config files to generate Kubernetes NetworkPolicies with evidence tracing.
+    - url: https://github.com/falcosecurity/falco
+      name: falcosecurity/falco
+      status: healthy
+      stars: 8955
+      forks: 1018
+      last_push: 2026-05-18T15:45:32Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Security
+      description: Sysdig Falco is an open source container security monitor. It can monitor application, container, host, and network activity and alert on unauthorized activity.
+    - url: https://github.com/AbianS/docker-db-manager
+      name: AbianS/docker-db-manager
+      status: healthy
+      stars: 161
+      forks: 5
+      last_push: 2026-04-12T18:29:18Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Desktop
+      description: Desktop app for managing Docker database containers with visual interface and one-click operations.
+    - url: https://github.com/felixgborrego/simple-docker-ui
+      name: felixgborrego/simple-docker-ui
+      status: inactive
+      stars: 603
+      forks: 96
+      last_push: 2024-09-06T09:31:07Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Desktop
+      description: Built on Electron.
+    - url: https://github.com/slonopotamus/stevedore
+      name: slonopotamus/stevedore
+      status: healthy
+      stars: 372
+      forks: 13
+      last_push: 2026-04-13T09:17:09Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Desktop
+      description: Good Docker Desktop replacement for Windows. Both Linux and Windows Containers are supported. [slonopotamus](https://github.com/slonopotamus).
+    - url: https://github.com/jr-k/d4s
+      name: jr-k/d4s
+      status: healthy
+      stars: 83
       forks: 7
-      last_push: 2018-11-16T21:54:44Z
+      last_push: 2026-05-12T21:41:45Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: Docker event handling with Python.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A fast, keyboard-driven terminal UI to manage Docker containers, Compose stacks, and Swarm services with the ergonomics of K9s.
+    - url: https://github.com/Falldog/dcinja
+      name: Falldog/dcinja
+      status: healthy
+      stars: 14
+      forks: 3
+      last_push: 2025-06-26T12:33:01Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: The powerful and smallest binary size of template engine for docker command line environment.
+    - url: https://github.com/FabienD/docker-stack
+      name: FabienD/docker-stack
+      status: healthy
+      stars: 23
+      forks: 2
+      last_push: 2026-04-14T17:03:45Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Dctl is a Cli tool that helps developers by allowing them to execute all docker compose commands anywhere in the terminal, and more.
+    - url: https://github.com/s0rg/decompose
+      name: s0rg/decompose
+      status: healthy
+      stars: 134
+      forks: 6
+      last_push: 2026-04-08T19:31:21Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Reverse-engineering tool for docker environments.
+    - url: https://github.com/wagoodman/dive
+      name: wagoodman/dive
+      status: healthy
+      stars: 53952
+      forks: 1996
+      last_push: 2025-12-15T17:20:36Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A tool for exploring each layer in a docker image.
+    - url: https://github.com/christian-korneck/docker-pushrm
+      name: christian-korneck/docker-pushrm
+      status: inactive
+      stars: 151
+      forks: 3
+      last_push: 2024-06-10T21:42:09Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A Docker CLI plugin that lets you push the README.md file from the current directory to Docker Hub. Also supports Quay and Harbor.
+    - url: https://github.com/lucabello/docker-captain
+      name: lucabello/docker-captain
+      status: healthy
+      stars: 2
+      last_push: 2026-04-25T00:13:57Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A friendly CLI to manage multiple Docker Compose deployments with style — powered by Typer, Rich, questionary, and sh.
+    - url: https://github.com/spotify/dockerfile-mode
+      name: spotify/dockerfile-mode
+      status: healthy
+      stars: 564
+      forks: 84
+      last_push: 2025-12-21T16:45:00Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: An Emacs mode for handling Dockerfiles.
+    - url: https://github.com/patrickhoefler/dockerfilegraph
+      name: patrickhoefler/dockerfilegraph
+      status: healthy
+      stars: 264
+      forks: 17
+      last_push: 2026-05-16T08:01:28Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Visualize your multi-stage Dockerfiles.
+    - url: https://github.com/lirantal/dockly
+      name: lirantal/dockly
+      status: healthy
+      stars: 4015
+      forks: 164
+      last_push: 2026-05-18T08:16:52Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: An interactive shell UI for managing Docker containers.
+    - url: https://github.com/shubh-io/dockmate
+      name: shubh-io/dockmate
+      status: healthy
+      stars: 314
+      forks: 5
+      last_push: 2026-04-06T07:04:40Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Lightweight terminal-based Docker and Podman manager with a text-based user interface,.
+    - url: https://github.com/GhostWriters/DockSTARTer
+      name: GhostWriters/DockSTARTer
+      status: healthy
+      stars: 2560
+      forks: 291
+      last_push: 2026-05-18T07:11:11Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: DockSTARTer helps you get started with home server apps running in Docker.
+    - url: https://github.com/durableprogramming/dprs
+      name: durableprogramming/dprs
+      status: healthy
+      stars: 38
+      forks: 1
+      last_push: 2026-03-05T15:59:19Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A developer-focused TUI for managing Docker containers with real-time log streaming and container management.
+    - url: https://github.com/moncho/dry
+      name: moncho/dry
+      status: healthy
+      stars: 3250
+      forks: 103
+      last_push: 2026-04-09T12:13:58Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: An interactive CLI for Docker containers.
+    - url: https://github.com/joao-zanutto/easydocker
+      name: joao-zanutto/easydocker
+      status: healthy
+      stars: 112
+      forks: 4
+      last_push: 2026-05-16T18:06:58Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A Terminal UI highly inpired by k9s levaraging beatiful BubbleTea graphics.
+    - url: https://github.com/ajayd-san/gomanagedocker
+      name: ajayd-san/gomanagedocker
+      status: inactive
+      stars: 637
+      forks: 26
+      last_push: 2024-12-28T07:44:20Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: TUI tool to view and manage your docker objects blazingly fast with sensible keybindings, also supports VIM navigation out of the box.
+    - url: https://github.com/jesseduffield/lazydocker
+      name: jesseduffield/lazydocker
+      status: healthy
+      stars: 51076
+      forks: 1614
+      last_push: 2026-04-19T02:51:06Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.
+    - url: https://github.com/Lifailon/lazyjournal
+      name: Lifailon/lazyjournal
+      status: healthy
+      stars: 1267
+      forks: 31
+      last_push: 2026-05-06T07:54:47Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.
+    - url: https://github.com/mrjackwills/oxker
+      name: mrjackwills/oxker
+      status: healthy
+      stars: 1668
+      forks: 46
+      last_push: 2026-05-13T20:31:32Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A simple tui to view & control docker containers.
+    - url: https://github.com/shiwaforce/poco
+      name: shiwaforce/poco
+      status: healthy
+      stars: 113
+      forks: 6
+      last_push: 2026-02-28T12:31:09Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Proco will help you to organise and manage Docker, Docker-Compose, Kubernetes projects of any complexity using simple YAML config files to shorten the route from finding your project to initialising it in your local environment.
+    - url: https://github.com/JonathonReinhart/scuba
+      name: JonathonReinhart/scuba
+      status: healthy
+      stars: 97
+      forks: 17
+      last_push: 2026-01-26T04:03:05Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Transparently use Docker containers to encapsulate software build environments,.
+    - url: https://github.com/segersniels/supdock
+      name: segersniels/supdock
+      status: healthy
+      stars: 85
+      forks: 3
+      last_push: 2026-04-04T11:25:22Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Allows for slightly more visual usage of Docker with an interactive prompt.
+    - url: https://github.com/Eldara-Tech/swarmcli
+      name: Eldara-Tech/swarmcli
+      status: healthy
+      stars: 15
+      forks: 7
+      last_push: 2026-05-18T13:24:50Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: Swarm Management at the speed of thought — with real-time log streaming, instant shell access to containers, seamless port forwarding, and on-demand secret reveal capabilities, giving you full control over your Docker Swarm without breaking your flow.
+    - url: https://github.com/pivovarit/tdocker
+      name: pivovarit/tdocker
+      status: healthy
+      stars: 84
+      forks: 3
+      last_push: 2026-05-16T06:18:16Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A `docker ps` replacement for everyday container operations.
+    - url: https://github.com/idesyatov/wharf
+      name: idesyatov/wharf
+      status: healthy
+      stars: 3
+      last_push: 2026-05-05T21:32:22Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Terminal
+      description: A k9s-inspired TUI for Docker Compose with vim-style navigation, real-time CPU/MEM monitoring with braille charts, container file browser, SSH remote host support, and command mode.
+    - url: https://github.com/getarcaneapp/arcane
+      name: getarcaneapp/arcane
+      status: healthy
+      stars: 5540
+      forks: 196
+      last_push: 2026-05-18T20:58:23Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: An easy and modern Docker management platform, built with everybody in mind.
+    - url: https://github.com/knrdl/casa
+      name: knrdl/casa
+      status: healthy
+      stars: 85
+      forks: 6
+      last_push: 2026-05-18T07:49:43Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Outsource the administration of a handful of containers to your co-workers,.
+    - url: https://github.com/wrfly/container-web-tty
+      name: wrfly/container-web-tty
+      status: healthy
+      stars: 258
+      forks: 46
+      last_push: 2026-04-16T20:52:12Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Connect your containers via a web-tty.
+    - url: https://github.com/klausmeyer/docker-registry-browser
+      name: klausmeyer/docker-registry-browser
+      status: healthy
+      stars: 686
+      forks: 62
+      last_push: 2026-05-16T09:56:13Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Web Interface for the Docker Registry HTTP API v2.
+    - url: https://github.com/dockersamples/docker-swarm-visualizer
+      name: dockersamples/docker-swarm-visualizer
+      status: inactive
+      stars: 3348
+      forks: 594
+      last_push: 2024-10-26T07:12:05Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Visualizes Docker services on a Docker Swarm (for running demos).
+    - url: https://github.com/louislam/dockge
+      name: louislam/dockge
+      status: healthy
+      stars: 23237
+      forks: 749
+      last_push: 2026-04-25T02:28:26Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.
+    - url: https://github.com/mbecker20/komodo
+      name: mbecker20/komodo
+      status: healthy
+      stars: 11195
+      forks: 318
+      last_push: 2026-05-12T01:45:09Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: A tool to build and deploy software on many servers.
+    - url: https://github.com/portainer/portainer
+      name: portainer/portainer
+      status: healthy
+      stars: 37470
+      forks: 2825
+      last_push: 2026-05-18T14:08:03Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: A lightweight management UI for managing your Docker hosts or Docker Swarm clusters.
+    - url: https://github.com/swarmpit/swarmpit
+      name: swarmpit/swarmpit
+      status: healthy
+      stars: 3438
+      forks: 312
+      last_push: 2026-05-14T19:15:12Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: Swarmpit provides simple and easy to use interface for your Docker Swarm cluster. You can manage your stacks, services, secrets, volumes, networks etc.
+    - url: https://github.com/fr4nsys/usulnet
+      name: fr4nsys/usulnet
+      status: healthy
+      stars: 97
+      forks: 5
+      last_push: 2026-05-16T18:56:39Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > User Interfaces > Web
+      description: A complete and modern Docker management platform designed for sysadmin, devops with enterprise grade tools, cve scanner, ssh, rdp on web and much more.
     - url: https://github.com/lispyclouds/contajners
       name: lispyclouds/contajners
       status: healthy
-      stars: 145
+      stars: 149
       forks: 8
-      last_push: 2026-02-20T09:07:36Z
+      last_push: 2026-04-14T19:20:40Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: An idiomatic, data-driven, REPL friendly Clojure client for OCI container engines. By [lispyclouds][lispyclouds].
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
+      description: An idiomatic, data-driven, REPL friendly Clojure client for OCI container engines.
     - url: https://github.com/gesellix/docker-client
       name: gesellix/docker-client
       status: healthy
-      stars: 119
+      stars: 121
       forks: 28
-      last_push: 2026-03-08T12:34:16Z
+      last_push: 2026-05-14T16:53:40Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: A Docker remote api client library for the JVM, written in Groovy.
     - url: https://github.com/dgongut/docker-controller-bot
       name: dgongut/docker-controller-bot
       status: healthy
-      stars: 241
-      forks: 31
-      last_push: 2026-02-04T15:58:07Z
+      stars: 247
+      forks: 33
+      last_push: 2026-05-07T16:18:27Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: Telegram bot to control docker containers. By [dgongut](https://github.com/dgongut/).
-    - url: https://github.com/whisklabs/docker-it-scala
-      name: whisklabs/docker-it-scala
-      status: stale
-      stars: 433
-      forks: 90
-      last_push: 2024-02-14T12:56:54Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: Docker integration testing kit with Scala.
-    - url: https://github.com/amihaiemil/docker-java-api
-      name: amihaiemil/docker-java-api
-      status: stale
-      stars: 274
-      forks: 55
-      last_push: 2021-06-04T01:21:45Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: Lightweight, truly object-oriented, Java client for Docker's API. By [amihaiemil](https://github.com/amihaiemil).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
+      description: Telegram bot to control docker containers.
     - url: https://github.com/fabric8io/docker-maven-plugin
       name: fabric8io/docker-maven-plugin
       status: healthy
-      stars: 1929
-      forks: 656
-      last_push: 2026-02-24T15:30:08Z
+      stars: 1930
+      forks: 655
+      last_push: 2026-04-01T04:59:19Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: A Maven plugin for running and creating Docker images.
     - url: https://github.com/Microsoft/Docker.DotNet
       name: Microsoft/Docker.DotNet
       status: healthy
-      stars: 2405
-      forks: 409
+      stars: 2411
+      forks: 411
       last_push: 2025-08-28T14:08:51Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: C#/.NET HTTP client for the Docker remote API.
     - url: https://github.com/ChangemakerStudios/Docker.Registry.DotNet
       name: ChangemakerStudios/Docker.Registry.DotNet
       status: healthy
       stars: 42
-      forks: 21
+      forks: 22
       last_push: 2025-10-06T03:43:52Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: .NET (C#) Client Library for interacting with a Docker Registry API (v2) [rquackenbush](https://github.com/rquackenbush).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
+      description: .NET (C#) Client Library for interacting with a Docker Registry API (v2).
     - url: https://github.com/apocas/dockerode
       name: apocas/dockerode
       status: healthy
-      stars: 4834
-      forks: 486
-      last_push: 2026-02-28T03:51:43Z
+      stars: 4891
+      forks: 488
+      last_push: 2026-05-13T09:09:35Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: Docker Remote API node.js module.
-    - url: https://github.com/eon01/DoMonit
-      name: eon01/DoMonit
-      status: stale
-      stars: 76
-      forks: 15
-      last_push: 2021-06-01T21:57:21Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: A simple Docker Monitoring wrapper For Docker API.
     - url: https://github.com/fsouza/go-dockerclient
       name: fsouza/go-dockerclient
       status: healthy
-      stars: 2236
+      stars: 2238
       forks: 556
-      last_push: 2026-03-06T04:10:21Z
+      last_push: 2026-05-11T03:54:15Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
+      checked_at: 2026-05-18T21:29:20.484404Z
     - url: https://github.com/gesellix/gradle-docker-plugin
       name: gesellix/gradle-docker-plugin
       status: healthy
       stars: 81
       forks: 17
-      last_push: 2026-03-08T12:36:04Z
+      last_push: 2026-05-12T20:22:08Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: A Docker remote api plugin for Gradle.
     - url: https://github.com/greenled/portainer-stack-utils
       name: greenled/portainer-stack-utils
@@ -2332,18 +1688,18 @@ entries:
       forks: 16
       last_push: 2025-12-05T02:34:50Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
-      description: Bash script to deploy/update/undeploy Docker stacks in a Portainer instance from a docker-compose yaml file. By [greenled](https://github.com/greenled).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
+      description: Bash script to deploy/update/undeploy Docker stacks in a Portainer instance from a docker-compose yaml file.
     - url: https://github.com/marcuslonnberg/sbt-docker
       name: marcuslonnberg/sbt-docker
       status: inactive
       stars: 733
-      forks: 112
+      forks: 113
       last_push: 2024-12-12T15:18:45Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > API Client
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > API Client
       description: Create Docker images directly from sbt.
     - url: https://github.com/harbur/captain
       name: harbur/captain
@@ -2352,96 +1708,76 @@ entries:
       forks: 48
       last_push: 2025-05-25T00:09:20Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Convert your Git workflow to Docker containers ready for Continuous Delivery.
-    - url: https://github.com/caicloud/cyclone
-      name: caicloud/cyclone
-      status: stale
-      stars: 1073
-      forks: 171
-      last_push: 2023-10-24T12:08:27Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Powerful workflow engine and end-to-end pipeline solutions implemented with native Kubernetes resources.
     - url: https://github.com/DefangLabs/defang
       name: DefangLabs/defang
       status: healthy
-      stars: 146
-      forks: 24
-      last_push: 2026-03-08T06:20:54Z
+      stars: 152
+      forks: 25
+      last_push: 2026-05-18T07:27:39Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Deploy Docker Compose to your favorite cloud in minutes.
     - url: https://github.com/crazy-max/diun
       name: crazy-max/diun
       status: healthy
-      stars: 4457
-      forks: 143
-      last_push: 2026-03-08T17:42:13Z
+      stars: 4664
+      forks: 148
+      last_push: 2026-05-16T11:01:06Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Receive notifications when an image or repository is updated on a Docker registry by [crazy-max].
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
+      description: Receive notifications when an image or repository is updated on a Docker registry.
     - url: https://github.com/mag37/dockcheck
       name: mag37/dockcheck
       status: healthy
-      stars: 2237
-      forks: 80
-      last_push: 2026-03-05T18:27:54Z
+      stars: 2328
+      forks: 85
+      last_push: 2026-05-15T12:20:42Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: A script checking updates for docker images without pulling then auto-update selected/all containers. With notifications, pruning and more.
     - url: https://github.com/jenkinsci/docker-plugin
       name: jenkinsci/docker-plugin
       status: healthy
-      stars: 499
+      stars: 498
       forks: 325
-      last_push: 2026-02-28T10:00:57Z
+      last_push: 2026-05-01T19:56:24Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
+      checked_at: 2026-05-18T21:29:20.484404Z
     - url: https://github.com/drone/drone
       name: drone/drone
       status: healthy
-      stars: 33861
-      forks: 2896
-      last_push: 2026-03-07T12:23:43Z
+      stars: 35900
+      forks: 3131
+      last_push: 2026-05-18T09:23:18Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Continuous integration server built on Docker and configured using YAML files.
-    - url: https://github.com/CodesWhat/drydock
-      name: CodesWhat/drydock
-      status: healthy
-      stars: 111
-      forks: 5
-      last_push: 2026-03-08T18:03:39Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Open-source container update monitoring with web dashboard, 15 registries, 16 notification triggers, and security scanning. Drop-in WUD replacement. By [CodesWhat](https://github.com/CodesWhat).
     - url: https://github.com/shizunge/gantry
       name: shizunge/gantry
       status: healthy
-      stars: 84
+      stars: 88
       forks: 4
-      last_push: 2026-03-06T03:39:21Z
+      last_push: 2026-05-12T22:46:38Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Automatically update selected Docker swarm services.
     - url: https://github.com/theSage21/jaypore_ci
       name: theSage21/jaypore_ci
       status: healthy
-      stars: 38
+      stars: 37
       forks: 4
       last_push: 2026-03-07T17:18:09Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Simple, very flexible, powerful CI / CD / automation system configured in Python. Offline and local first.
     - url: https://github.com/Kraken-CI/kraken
       name: Kraken-CI/kraken
@@ -2450,177 +1786,49 @@ entries:
       forks: 20
       last_push: 2026-01-15T13:00:32Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Modern CI/CD, open-source, on-premise system that is highly scalable and focused on testing. One of its executors is Docker. Developed.
-    - url: https://github.com/francescou/docker-continuous-deployment
-      name: francescou/docker-continuous-deployment
-      status: stale
-      stars: 145
-      forks: 38
-      last_push: 2017-08-01T17:25:15Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Continuous deployment of a microservices application.
-    - url: https://github.com/stelligent/mu
-      name: stelligent/mu
-      status: stale
-      stars: 965
-      forks: 133
-      last_push: 2020-06-18T14:09:29Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Tool to configure CI/CD of your container applications via AWS CodePipeline, CodeBuild and ECS [Stelligent](https://github.com/stelligent).
-    - url: https://github.com/systemslab/popper
-      name: systemslab/popper
-      status: stale
-      stars: 307
-      forks: 62
-      last_push: 2022-03-29T22:02:27Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Github actions workflow (HCL syntax) execution engine.
     - url: https://github.com/Stratoscale/skipper
       name: Stratoscale/skipper
       status: healthy
-      stars: 50
+      stars: 49
       forks: 22
-      last_push: 2025-05-13T13:33:39Z
+      last_push: 2026-05-17T10:55:56Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > CI/CD
       description: Easily dockerize your Git repository.
-    - url: https://github.com/ghostsquad/swarmci
-      name: ghostsquad/swarmci
-      status: stale
-      stars: 58
-      forks: 6
-      last_push: 2017-02-24T02:14:18Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > CI/CD
-      description: Create a distributed, isolated task pipeline in your Docker Swarm.
-    - url: https://github.com/binci/binci
-      name: binci/binci
-      status: stale
-      stars: 673
-      forks: 24
-      last_push: 2022-12-06T20:24:40Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Containerize your development workflow. (formerly DevLab by [TechnologyAdvice](https://github.com/TechnologyAdvice)).
     - url: https://github.com/coder/coder
       name: coder/coder
       status: healthy
-      stars: 12417
-      forks: 1194
-      last_push: 2026-03-08T17:58:52Z
+      stars: 13236
+      forks: 1296
+      last_push: 2026-05-18T21:21:02Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
       description: Remote development machines powered by Terraform or Docker.
-    - url: https://github.com/lstephen/construi
-      name: lstephen/construi
-      status: stale
-      stars: 24
-      forks: 5
-      last_push: 2022-12-08T06:36:04Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Run your builds inside a Docker defined environment.
     - url: https://github.com/whatwedo/dde
       name: whatwedo/dde
       status: healthy
-      stars: 46
+      stars: 45
       forks: 9
-      last_push: 2026-02-20T12:25:04Z
+      last_push: 2026-05-18T21:23:46Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Local development environment toolset based on Docker. By [whatwedo](https://github.com/whatwedo).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Local development environment toolset based on Docker.
     - url: https://github.com/bibendi/dip
       name: bibendi/dip
-      status: inactive
-      stars: 1324
+      status: healthy
+      stars: 1332
       forks: 50
-      last_push: 2024-12-25T09:38:57Z
+      last_push: 2026-05-18T17:40:08Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: CLI utility for straightforward provisioning and interacting with an application configured by docker-compose. By [bibendi](https://github.com/bibendi).
-    - url: https://github.com/dnephin/dobi
-      name: dnephin/dobi
-      status: stale
-      stars: 315
-      forks: 34
-      last_push: 2023-11-10T06:32:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: A build automation tool for Docker applications. By [dnephin](https://github.com/dnephin).
-    - url: https://github.com/nandoquintana/docker-missing-tools
-      name: nandoquintana/docker-missing-tools
-      status: stale
-      stars: 30
-      forks: 6
-      last_push: 2018-05-01T13:10:10Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: A set of bash commands to shortcut typical docker dev-ops. An alternative to creating typical helper scripts like "build.sh" and "deploy.sh" inside code repositories. By [NandoQuintana](https://github.com/nandoquintana).
-    - url: https://github.com/Ph3nol/Docker-Arch
-      name: Ph3nol/Docker-Arch
-      status: stale
-      stars: 31
-      forks: 2
-      last_push: 2018-09-24T06:43:08Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Generate Web/CLI projects Dockerized development environments, from 1 simple YAML file. By [Ph3nol](https://github.com/ph3nol).
-    - url: https://github.com/EugenMayer/docker-sync
-      name: EugenMayer/docker-sync
-      status: healthy
-      stars: 3564
-      forks: 285
-      last_push: 2025-11-30T20:06:16Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Drastically improves performance ([50-70x](https://github.com/EugenMayer/docker-sync/wiki/4.-Performance)) when using Docker for development on Mac OS X/Windows and Linux while sharing code to the container. By [EugenMayer](https://github.com/EugenMayer).
-    - url: https://github.com/shyiko/docker-vm
-      name: shyiko/docker-vm
-      status: stale
-      stars: 43
-      forks: 8
-      last_push: 2016-09-24T17:45:47Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Simple and transparent alternative to boot2docker (backed by Vagrant).
-    - url: https://github.com/matifali/dockerdl
-      name: matifali/dockerdl
-      status: healthy
-      stars: 86
-      forks: 11
-      last_push: 2025-12-29T19:27:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Deep Learning Docker Images. Don't waste time setting up a deep learning env when you can get a deep learning environment with everything pre-installed.
-    - url: https://github.com/eclipse/che
-      name: eclipse/che
-      status: healthy
-      stars: 7129
-      forks: 1200
-      last_push: 2026-03-06T15:10:49Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Developer workspace server with Docker runtimes, cloud IDE, next-generation Eclipse IDE.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: CLI utility for straightforward provisioning and interacting with an application configured by docker-compose.
     - url: https://github.com/EnvCLI/EnvCLI
       name: EnvCLI/EnvCLI
       status: healthy
@@ -2628,296 +1836,127 @@ entries:
       forks: 4
       last_push: 2025-06-16T20:36:16Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Replace your local installation of Node, Go, ... with project-specific docker containers. By [EnvCLI](https://github.com/EnvCLI).
-    - url: https://github.com/hpsaturn/esp32s3-linux
-      name: hpsaturn/esp32s3-linux
-      status: healthy
-      stars: 78
-      forks: 9
-      last_push: 2025-04-05T08:38:16Z
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Container solution to compile Linux and develop it for ESP32 microcontrollers - By [Hpsaturn](https://github.com/hpsaturn).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Replace your local installation of Node, Go, ... with project-specific docker containers.
     - url: https://github.com/moshebe/gebug
       name: moshebe/gebug
       status: healthy
-      stars: 634
+      stars: 633
       forks: 17
-      last_push: 2026-03-06T21:42:46Z
+      last_push: 2026-05-08T06:15:40Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
       description: A tool that makes debugging of Dockerized Go applications super easy by enabling Debugger and Hot-Reload features, seamlessly.
-    - url: https://github.com/senges/kitt
-      name: senges/kitt
-      status: stale
-      stars: 20
-      forks: 1
-      last_push: 2023-02-23T14:01:05Z
+    - url: https://github.com/potterwhite/HarborPilot
+      name: potterwhite/HarborPilot
+      status: healthy
+      stars: 2
+      last_push: 2026-05-18T01:14:58Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: A portable and disposable Shell environment, based on Docker and Nix. By [senges](https://github.com/senges).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Automated multi-platform Docker image builder for embedded Linux development (RK3588, RV1126, RK3568). Features three-layer config inheritance, PORT_SLOT-based port allocation, and cross-version Ubuntu support (20.04/22.04/24.04).
     - url: https://github.com/lando/lando
       name: lando/lando
       status: healthy
-      stars: 4222
-      forks: 527
-      last_push: 2026-02-24T21:10:02Z
+      stars: 4232
+      forks: 520
+      last_push: 2026-04-28T22:30:42Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Lando is for developers who want to quickly specify and painlessly spin up the services and tools needed to develop their projects. By [Tandem](https://www.thinktandem.io/).
-    - url: https://github.com/Peco602/rust-universal-compiler
-      name: Peco602/rust-universal-compiler
-      status: stale
-      stars: 33
-      forks: 2
-      last_push: 2023-04-30T17:04:02Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Container solution to compile Rust projects for Linux, macOS and Windows. By [Peco602][peco602].
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Lando is for developers who want to quickly specify and painlessly spin up the services and tools needed to develop their projects.
     - url: https://github.com/uniget-org/cli
       name: uniget-org/cli
       status: healthy
       stars: 20
-      last_push: 2026-02-12T08:35:24Z
+      last_push: 2026-05-12T14:55:25Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Uni(versal)get, the installer and updater for container tools and beyond (formerly docker-setup). By [nicholasdille](https://github.com/nicholasdille).
-    - url: https://github.com/tailhook/vagga
-      name: tailhook/vagga
-      status: stale
-      stars: 1896
-      forks: 96
-      last_push: 2023-03-31T06:13:55Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Vagga is a containerisation tool without daemons. It is a fully-userspace container engine inspired by Vagrant and Docker, specialized for development environments.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Uni(versal)get, the installer and updater for container tools and beyond (formerly docker-setup).
     - url: https://github.com/deluan/zsh-in-docker
       name: deluan/zsh-in-docker
       status: inactive
-      stars: 1096
-      forks: 119
+      stars: 1106
+      forks: 122
       last_push: 2024-09-30T19:07:49Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Development Environment
-      description: Install Zsh, Oh-My-Zsh and plugins inside a Docker container with one line! By [Deluan](https://www.deluan.com).
-    - url: https://github.com/tjamet/caduc
-      name: tjamet/caduc
-      status: stale
-      stars: 21
-      forks: 1
-      last_push: 2019-01-07T16:07:50Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Garbage Collection
-      description: A docker garbage collector cleaning stuff you did not use recently.
-    - url: https://github.com/ZZROTDesign/docker-clean
-      name: ZZROTDesign/docker-clean
-      status: stale
-      stars: 1304
-      forks: 90
-      last_push: 2018-01-16T16:29:41Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Garbage Collection
-      description: A script that cleans Docker containers, images and volumes.
-    - url: https://github.com/Yelp/docker-custodian
-      name: Yelp/docker-custodian
-      status: inactive
-      stars: 374
-      forks: 49
-      last_push: 2024-08-14T08:08:10Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Garbage Collection
-      description: Keep docker hosts tidy. By [Yelp](https://github.com/Yelp).
-    - url: https://github.com/pdacity/docker_gc
-      name: pdacity/docker_gc
-      status: stale
-      stars: 128
-      forks: 22
-      last_push: 2024-02-09T17:50:47Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Garbage Collection
-      description: Image for automatic removing unused Docker Swarm objects. Also works just as Docker Service.
-    - url: https://github.com/stepchowfun/docuum
-      name: stepchowfun/docuum
-      status: healthy
-      stars: 684
-      forks: 43
-      last_push: 2026-03-07T22:59:03Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Garbage Collection
-      description: Least recently used (LRU) eviction of Docker images.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Development Environment
+      description: Install Zsh, Oh-My-Zsh and plugins inside a Docker container with one line!.
     - url: https://github.com/apache/openwhisk
       name: apache/openwhisk
       status: healthy
-      stars: 6757
-      forks: 1174
-      last_push: 2026-01-24T05:17:06Z
+      stars: 6778
+      forks: 1177
+      last_push: 2026-05-07T14:42:56Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Serverless
-      description: A serverless, open source cloud platform that executes functions in response to events at any scale. By [apache](https://github.com/apache).
-    - url: https://github.com/bfirsh/funker-example-voting-app
-      name: bfirsh/funker-example-voting-app
-      status: stale
-      stars: 26
-      forks: 8
-      last_push: 2016-11-29T11:51:39Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Serverless
-      description: Functions as Docker containers example voting app. By [bfirsh](https://github.com/bfirsh).
-    - url: https://github.com/iron-io/functions
-      name: iron-io/functions
-      status: stale
-      stars: 3220
-      forks: 224
-      last_push: 2023-09-15T01:37:58Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Serverless
-      description: The serverless microservices platform FaaS (Functions as a Service) which uses Docker containers to run Any language or AWS Lambda functions.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Serverless
+      description: A serverless, open source cloud platform that executes functions in response to events at any scale.
     - url: https://github.com/openfaas/faas
       name: openfaas/faas
       status: healthy
-      stars: 26105
-      forks: 1970
-      last_push: 2026-02-22T08:49:51Z
+      stars: 26151
+      forks: 1968
+      last_push: 2026-04-01T14:03:53Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Serverless
-      description: A complete serverless functions framework for Docker and Kubernetes. By [OpenFaaS](https://github.com/openfaas).
-    - url: https://github.com/grycap/scar
-      name: grycap/scar
-      status: stale
-      stars: 599
-      forks: 47
-      last_push: 2023-05-22T11:01:11Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Serverless
-      description: Serverless Container-aware Architectures (SCAR) is a serverless framework that allows easy deployment and execution of containers (e.g. Docker) in Serverless environments (e.g. Lambda).
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Serverless
+      description: A complete serverless functions framework for Docker and Kubernetes.
     - url: https://github.com/GoogleContainerTools/container-structure-test
       name: GoogleContainerTools/container-structure-test
       status: healthy
-      stars: 2462
-      forks: 207
-      last_push: 2026-02-20T23:41:16Z
+      stars: 2477
+      forks: 206
+      last_push: 2026-04-15T19:06:22Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Testing
-      description: A framework to validate the structure of an image by checking the outputs of commands or the contents of the filesystem. By [GoogleContainerTools][googlecontainertools].
-    - url: https://github.com/zuazo/dockerspec
-      name: zuazo/dockerspec
-      status: stale
-      stars: 181
-      forks: 8
-      last_push: 2017-08-30T20:40:57Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Testing
-      description: A small Ruby Gem to run RSpec and Serverspec, Infrataster and Capybara tests against Dockerfiles or Docker images easily. By [zuazo](https://github.com/zuazo).
-    - url: https://github.com/lynchborg/ezdc
-      name: lynchborg/ezdc
-      status: stale
-      stars: 12
-      last_push: 2024-02-12T08:42:24Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Testing
-      description: Golang test harness for easily setting up tests that rely on services in a docker-compose.yml. By [byrnedo].
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Testing
+      description: A framework to validate the structure of an image by checking the outputs of commands or the contents of the filesystem.
     - url: https://github.com/kurtosis-tech/kurtosis
       name: kurtosis-tech/kurtosis
       status: healthy
-      stars: 526
-      forks: 90
-      last_push: 2026-03-06T11:06:13Z
+      stars: 539
+      forks: 96
+      last_push: 2026-05-18T19:15:12Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Testing
-      description: 'A composable build system for multi-container test environments that provides developers with: a powerful Python-like SDK for environment configuration, a compile-time validator to verify environment behavior & setup, and a runtime for environment execution, monitoring, & debugging capabilities. By [Kurtosis](https://www.kurtosis.com/).'
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Testing
+      description: 'A composable build system for multi-container test environments that provides developers with: a powerful Python-like SDK for environment configuration, a compile-time validator to verify environment behavior & setup, and a runtime for environment execution, monitoring, & debugging capabilities.'
     - url: https://github.com/alexei-led/pumba
       name: alexei-led/pumba
       status: healthy
-      stars: 3000
-      forks: 201
-      last_push: 2026-03-01T21:26:21Z
+      stars: 3025
+      forks: 204
+      last_push: 2026-05-11T03:24:44Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Testing
-      description: Chaos testing tool for Docker. Can be deployed on kubernetes and CoreOS cluster. By [alexei-led](https://github.com/alexei-led).
-    - url: https://github.com/docker-exec/dexec
-      name: docker-exec/dexec
-      status: stale
-      stars: 332
-      forks: 14
-      last_push: 2021-05-13T06:04:19Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: Command line interface written in Go for running code with Docker Exec images.
-    - url: https://github.com/benzaita/dockerized-cli
-      name: benzaita/dockerized-cli
-      status: stale
-      stars: 65
-      forks: 5
-      last_push: 2024-02-27T13:49:38Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: Seamlessly execute commands in a container.
-    - url: https://github.com/CenturyLinkLabs/dray
-      name: CenturyLinkLabs/dray
-      status: stale
-      stars: 386
-      forks: 37
-      last_push: 2020-01-24T17:34:58Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: An engine for managing the execution of container-based workflows.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Testing
+      description: Chaos testing tool for Docker. Can be deployed on kubernetes and CoreOS cluster.
     - url: https://github.com/artsy/hokusai
       name: artsy/hokusai
       status: healthy
-      stars: 98
+      stars: 97
       forks: 25
-      last_push: 2026-03-06T10:57:58Z
+      last_push: 2026-03-23T08:23:07Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Wrappers
       description: A Docker + Kubernetes CLI for application developers; used to containerize an application and to manage its lifecycle throughout development, testing, and release cycles. From [artsy](https://github.com/artsy).
     - url: https://github.com/livecycle/preevy
       name: livecycle/preevy
       status: healthy
-      stars: 2191
-      forks: 87
+      stars: 2209
+      forks: 89
       last_push: 2026-02-06T07:38:46Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Wrappers
       description: Preview environments for Docker and Docker Compose projects. Test your changes and get feedback from devs and non-devs (Product/Design) by deploying pull requests to the your cloud provider as part of your CI pipeline.
-    - url: https://github.com/ianmiell/shutit
-      name: ianmiell/shutit
-      status: stale
-      stars: 2144
-      forks: 110
-      last_push: 2022-08-14T14:43:18Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: Tool for building and maintaining complex Docker deployments.
     - url: https://github.com/subuser-security/subuser
       name: subuser-security/subuser
       status: inactive
@@ -2925,86 +1964,124 @@ entries:
       forks: 63
       last_push: 2025-02-23T11:31:31Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Wrappers
       description: Makes it easy to securely and portably run graphical desktop applications in Docker.
-    - url: https://github.com/christippett/terraform-cloudinit-container-server
-      name: christippett/terraform-cloudinit-container-server
-      status: stale
-      stars: 120
-      forks: 30
-      last_push: 2022-08-19T06:41:50Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: Terraform module for deploying a single Docker image or `docker-compose.yaml` file to any Cloud™ VM.
-    - url: https://github.com/ramitsurana/turbo
-      name: ramitsurana/turbo
-      status: stale
-      stars: 27
-      forks: 12
-      last_push: 2021-12-22T19:03:53Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
-      description: Simple and Powerful utility for docker. By [ramitsurana][ramitsurana].
     - url: https://github.com/indigo-dc/udocker
       name: indigo-dc/udocker
       status: healthy
-      stars: 1709
-      forks: 164
+      stars: 1744
+      forks: 167
       last_push: 2025-08-13T17:21:57Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Development with Docker > Wrappers
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > Developer Workflow > Wrappers
       description: A tool to execute simple docker containers in batch or interactive systems without root privileges.
-    - url: https://github.com/Appdynamics/docker-monitoring-extension
-      name: Appdynamics/docker-monitoring-extension
-      status: inactive
-      stars: 5
+    - url: https://github.com/iximiuz/cdebug
+      name: iximiuz/cdebug
+      status: healthy
+      stars: 1645
+      forks: 67
+      last_push: 2026-01-18T19:11:25Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Swiss-army knife for debugging running containers via ephemeral sidecars; works with Docker, containerd, and Kubernetes.
+    - url: https://github.com/nicomt/ckron
+      name: nicomt/ckron
+      status: healthy
+      stars: 56
       forks: 6
-      last_push: 2024-10-02T10:48:59Z
+      last_push: 2026-02-15T17:58:14Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Services based on Docker (mostly :heavy_dollar_sign:) > Monitoring Services
-      description: Docker Monitoring extension gathers metrics from the Docker Remote API, either using Unix Socket or TCP.
-    - url: https://github.com/sematext/sematext-agent-docker
-      name: sematext/sematext-agent-docker
-      status: stale
-      stars: 208
-      forks: 32
-      last_push: 2023-12-09T18:07:20Z
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: A cron-style job scheduler for docker,.
+    - url: https://github.com/jwilder/docker-gen
+      name: jwilder/docker-gen
+      status: healthy
+      stars: 4627
+      forks: 613
+      last_push: 2026-05-11T08:49:02Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Projects > Services based on Docker (mostly :heavy_dollar_sign:) > Monitoring Services
-      description: Monitoring of host and container metrics, Docker events and logs. Automatic log parser. Anomaly Detection and alerting for metrics and logs. [sematext](https://github.com/sematext).
-    - url: https://github.com/cicdops/awesome-ciandcd
-      name: cicdops/awesome-ciandcd
-      status: inactive
-      stars: 1987
-      forks: 225
-      last_push: 2024-04-01T18:08:23Z
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Generate files from docker container meta-data.
+    - url: https://github.com/powerman/dockerize
+      name: powerman/dockerize
+      status: healthy
+      stars: 194
+      forks: 18
+      last_push: 2026-05-04T22:40:14Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Useful Resources > Awesome Lists
-      description: Not specific to docker but relevant.
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Utility to simplify running applications in docker containers.
+    - url: https://github.com/tianon/gosu
+      name: tianon/gosu
+      status: healthy
+      stars: 4969
+      forks: 358
+      last_push: 2026-03-04T18:27:37Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Run this specific application as this specific user and get out of the pipeline (entrypoint script tool).
+    - url: https://github.com/sindresorhus/is-docker
+      name: sindresorhus/is-docker
+      status: healthy
+      stars: 233
+      forks: 15
+      last_push: 2025-09-15T21:04:10Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Check if the process is running inside a Docker container.
+    - url: https://github.com/tarampampam/microcheck
+      name: tarampampam/microcheck
+      status: healthy
+      stars: 142
+      forks: 2
+      last_push: 2026-05-08T09:33:51Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Lightweight health check utilities for Docker containers (75 KB instead of 9.3 MB for httpcheck versus cURL) in pure C - http(s), port checks, and parallel execution are included.
+    - url: https://github.com/mcuadros/ofelia
+      name: mcuadros/ofelia
+      status: healthy
+      stars: 3845
+      forks: 203
+      last_push: 2026-05-07T16:54:33Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+    - url: https://github.com/ncopa/su-exec
+      name: ncopa/su-exec
+      status: healthy
+      stars: 1018
+      forks: 103
+      last_push: 2025-10-07T13:49:01Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: This is a simple tool that will simply execute a program with different privileges. The program will be executed directly and not run as a child, like su and sudo does, which avoids TTY and signal issues. Why reinvent gosu? This does more or less exactly the same thing as gosu but it is only 10kb instead of 1.8MB.
+    - url: https://github.com/aptible/supercronic
+      name: aptible/supercronic
+      status: healthy
+      stars: 2498
+      forks: 141
+      last_push: 2026-04-23T12:10:59Z
+      has_license: true
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Projects > In-Container Tooling
+      description: Crontab-compatible job runner, designed specifically to run in containers.
     - url: https://github.com/docker/awesome-compose
       name: docker/awesome-compose
       status: healthy
-      stars: 44283
-      forks: 8070
-      last_push: 2026-03-05T09:59:09Z
+      stars: 45326
+      forks: 8149
+      last_push: 2026-05-09T12:17:01Z
       has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Useful Resources > Awesome Lists
+      checked_at: 2026-05-18T21:29:20.484404Z
+      category: Learning Resources > Awesome Lists
       description: Docker Compose samples.
-    - url: https://github.com/hexops/dockerfile
-      name: hexops/dockerfile
-      status: stale
-      stars: 4091
-      forks: 155
-      last_push: 2021-08-08T04:42:37Z
-      has_license: true
-      checked_at: 2026-03-08T18:26:00.233336Z
-      category: Useful Resources > Good Tips
-      description: This repository has best-practices for writing Dockerfiles.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veggiemonk/awesome-docker
 
-go 1.26.0
+go 1.26.3
 
 require (
 	charm.land/bubbletea/v2 v2.0.6
@@ -14,7 +14,7 @@ require (
 
 require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260511121909-c840852527f3 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
@@ -30,5 +30,5 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0y1Zo5KB/5Vu8JZoLGm1N3RzF9bNj3Ao3xoR+Ac=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
+github.com/charmbracelet/ultraviolet v0.0.0-20260511121909-c840852527f3 h1:pxGjlWZFcRQMWAdtjRelpL3Gbu8iYIyuO3Eqbd037Ow=
+github.com/charmbracelet/ultraviolet v0.0.0-20260511121909-c840852527f3/go.mod h1:SnKWaPaTnkTNXJgdgdquu66de12V8pW/b/qlTGaF9xg=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
@@ -56,6 +58,8 @@ golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -2,8 +2,10 @@ package builder
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/yuin/goldmark"
@@ -61,10 +63,13 @@ func Build(markdownPath, templatePath, outputPath string) error {
 		}
 	}
 	if !replaced {
-		return fmt.Errorf("template missing supported markdown placeholder")
+		return errors.New("template missing supported markdown placeholder")
 	}
 
-	if err := os.WriteFile(outputPath, []byte(output), 0o644); err != nil {
+	// outputPath is a CLI-provided destination for a generated website file;
+	// the user controls the destination by design, so the taint warning is expected.
+	//nolint:gosec // G306,G304: user-supplied output path is intentional for this CLI
+	if err := os.WriteFile(filepath.Clean(outputPath), []byte(output), 0o644); err != nil {
 		return fmt.Errorf("write output: %w", err)
 	}
 	return nil

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -38,17 +38,17 @@ func LoadExcludeList(path string) (*ExcludeList, error) {
 
 // HealthEntry stores metadata about a single entry.
 type HealthEntry struct {
-	URL        string    `yaml:"url"`
-	Name       string    `yaml:"name"`
-	Status     string    `yaml:"status"` // healthy, inactive, stale, archived, dead
-	Stars      int       `yaml:"stars,omitempty"`
-	Forks      int       `yaml:"forks,omitempty"`
-	LastPush   time.Time `yaml:"last_push,omitempty"`
-	HasLicense  bool      `yaml:"has_license,omitempty"`
-	HasReadme   bool      `yaml:"has_readme,omitempty"`
+	LastPush    time.Time `yaml:"last_push,omitempty"`
 	CheckedAt   time.Time `yaml:"checked_at"`
+	URL         string    `yaml:"url"`
+	Name        string    `yaml:"name"`
+	Status      string    `yaml:"status"`
 	Category    string    `yaml:"category,omitempty"`
 	Description string    `yaml:"description,omitempty"`
+	Stars       int       `yaml:"stars,omitempty"`
+	Forks       int       `yaml:"forks,omitempty"`
+	HasLicense  bool      `yaml:"has_license,omitempty"`
+	HasReadme   bool      `yaml:"has_readme,omitempty"`
 }
 
 // HealthCache is the full YAML cache file.
@@ -84,15 +84,17 @@ func SaveHealthCache(path string, hc *HealthCache) error {
 // Merge updates the cache with new entries, replacing existing ones by URL.
 func (hc *HealthCache) Merge(entries []HealthEntry) {
 	index := make(map[string]int)
-	for i, e := range hc.Entries {
+	for i := range hc.Entries {
+		e := &hc.Entries[i]
 		index[e.URL] = i
 	}
-	for _, e := range entries {
-		if i, exists := index[e.URL]; exists {
-			hc.Entries[i] = e
+	for i := range entries {
+		e := &entries[i]
+		if j, exists := index[e.URL]; exists {
+			hc.Entries[j] = *e
 		} else {
 			index[e.URL] = len(hc.Entries)
-			hc.Entries = append(hc.Entries, e)
+			hc.Entries = append(hc.Entries, *e)
 		}
 	}
 }

--- a/internal/checker/github.go
+++ b/internal/checker/github.go
@@ -13,15 +13,15 @@ import (
 
 // RepoInfo holds metadata about a GitHub repository.
 type RepoInfo struct {
+	PushedAt   time.Time
 	Owner      string
 	Name       string
 	URL        string
+	Stars      int
+	Forks      int
 	IsArchived bool
 	IsDisabled bool
 	IsPrivate  bool
-	PushedAt   time.Time
-	Stars      int
-	Forks      int
 	HasLicense bool
 }
 
@@ -104,15 +104,13 @@ func NewGitHubChecker(token string) *GitHubChecker {
 func (gc *GitHubChecker) CheckRepo(ctx context.Context, owner, name string) (RepoInfo, error) {
 	var query struct {
 		Repository struct {
+			PushedAt       time.Time
+			LicenseInfo    *struct{ Name string }
+			StargazerCount int
+			ForkCount      int
 			IsArchived     bool
 			IsDisabled     bool
 			IsPrivate      bool
-			PushedAt       time.Time
-			StargazerCount int
-			ForkCount      int
-			LicenseInfo    *struct {
-				Name string
-			}
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 

--- a/internal/checker/github.go
+++ b/internal/checker/github.go
@@ -116,7 +116,7 @@ func (gc *GitHubChecker) CheckRepo(ctx context.Context, owner, name string) (Rep
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(name),
 	}

--- a/internal/checker/github_test.go
+++ b/internal/checker/github_test.go
@@ -34,7 +34,14 @@ func TestExtractGitHubRepo(t *testing.T) {
 		}
 		if ok {
 			if owner != tt.owner || name != tt.name {
-				t.Errorf("ExtractGitHubRepo(%q) = (%q, %q), want (%q, %q)", tt.url, owner, name, tt.owner, tt.name)
+				t.Errorf(
+					"ExtractGitHubRepo(%q) = (%q, %q), want (%q, %q)",
+					tt.url,
+					owner,
+					name,
+					tt.owner,
+					tt.name,
+				)
 			}
 		}
 	}

--- a/internal/checker/http.go
+++ b/internal/checker/http.go
@@ -18,11 +18,11 @@ const (
 // LinkResult holds the result of checking a single URL.
 type LinkResult struct {
 	URL         string
-	OK          bool
-	StatusCode  int
-	Redirected  bool
 	RedirectURL string
 	Error       string
+	StatusCode  int
+	OK          bool
+	Redirected  bool
 }
 
 func shouldFallbackToGET(statusCode int) bool {

--- a/internal/linter/fixer.go
+++ b/internal/linter/fixer.go
@@ -15,7 +15,9 @@ import (
 //	by [@author](url), by [@author][ref], by @author
 //
 // Also handles "Created by", "Maintained by" etc.
-var attributionRe = regexp.MustCompile(`\s+(?:(?:[Cc]reated|[Mm]aintained|[Bb]uilt)\s+)?by\s+\[@[^\]]+\](?:\([^)]*\)|\[[^\]]*\])\.?$`)
+var attributionRe = regexp.MustCompile(
+	`\s+(?:(?:[Cc]reated|[Mm]aintained|[Bb]uilt)\s+)?by\s+\[@[^\]]+\](?:\([^)]*\)|\[[^\]]*\])\.?$`,
+)
 
 // bareAttributionRe matches: by @author at end of line (no link).
 var bareAttributionRe = regexp.MustCompile(`\s+by\s+@\w+\.?$`)
@@ -136,13 +138,19 @@ func FixFile(path string) (int, error) {
 
 	w := bufio.NewWriter(out)
 	for i, line := range lines {
-		w.WriteString(line)
+		if _, err := w.WriteString(line); err != nil {
+			return 0, err
+		}
 		if i < len(lines)-1 {
-			w.WriteString("\n")
+			if _, err := w.WriteString("\n"); err != nil {
+				return 0, err
+			}
 		}
 	}
 	// Preserve trailing newline if original had one
-	w.WriteString("\n")
+	if _, err := w.WriteString("\n"); err != nil {
+		return 0, err
+	}
 	return fixCount, w.Flush()
 }
 
@@ -218,11 +226,17 @@ func SortFile(path string) (int, error) {
 
 	w := bufio.NewWriter(out)
 	for i, line := range lines {
-		w.WriteString(line)
+		if _, err := w.WriteString(line); err != nil {
+			return 0, err
+		}
 		if i < len(lines)-1 {
-			w.WriteString("\n")
+			if _, err := w.WriteString("\n"); err != nil {
+				return 0, err
+			}
 		}
 	}
-	w.WriteString("\n")
+	if _, err := w.WriteString("\n"); err != nil {
+		return 0, err
+	}
 	return fixCount, w.Flush()
 }

--- a/internal/linter/rules.go
+++ b/internal/linter/rules.go
@@ -30,9 +30,9 @@ const (
 // Issue is a single lint problem found.
 type Issue struct {
 	Rule     Rule
+	Message  string
 	Severity Severity
 	Line     int
-	Message  string
 }
 
 func (i Issue) String() string {
@@ -79,7 +79,11 @@ func CheckSorted(entries []parser.Entry) []Issue {
 				Rule:     RuleSorted,
 				Severity: SeverityError,
 				Line:     entries[i].Line,
-				Message:  fmt.Sprintf("%q should come before %q (alphabetical order)", entries[i].Name, entries[i-1].Name),
+				Message: fmt.Sprintf(
+					"%q should come before %q (alphabetical order)",
+					entries[i].Name,
+					entries[i-1].Name,
+				),
 			})
 		}
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -19,7 +19,11 @@ func TestParseEntry(t *testing.T) {
 		t.Errorf("url = %q, want %q", entry.URL, "https://www.docker.com/products/docker-desktop/")
 	}
 	if entry.Description != "Official native app. Only for Windows and MacOS." {
-		t.Errorf("description = %q, want %q", entry.Description, "Official native app. Only for Windows and MacOS.")
+		t.Errorf(
+			"description = %q, want %q",
+			entry.Description,
+			"Official native app. Only for Windows and MacOS.",
+		)
 	}
 	if len(entry.Markers) != 0 {
 		t.Errorf("markers = %v, want empty", entry.Markers)

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -15,17 +15,17 @@ type Entry struct {
 	Name        string
 	URL         string
 	Description string
+	Raw         string
 	Markers     []Marker
-	Line        int    // 1-based line number in source
-	Raw         string // original line text
+	Line        int
 }
 
 // Section is a heading with optional entries and child sections.
 type Section struct {
 	Title    string
-	Level    int // heading level: 1 = #, 2 = ##, etc.
 	Entries  []Entry
 	Children []Section
+	Level    int
 	Line     int
 }
 

--- a/internal/pruner/pruner.go
+++ b/internal/pruner/pruner.go
@@ -42,9 +42,10 @@ func TargetURLs(hc *cache.HealthCache, statuses []string) map[string]cache.Healt
 		want[strings.TrimSpace(strings.ToLower(s))] = true
 	}
 	out := make(map[string]cache.HealthEntry)
-	for _, e := range hc.Entries {
+	for i := range hc.Entries {
+		e := &hc.Entries[i]
 		if want[strings.ToLower(e.Status)] {
-			out[normalizeURL(e.URL)] = e
+			out[normalizeURL(e.URL)] = *e
 		}
 	}
 	return out
@@ -115,11 +116,12 @@ func PruneCache(path string, hc *cache.HealthCache, targets map[string]cache.Hea
 		return 0, nil
 	}
 	kept := hc.Entries[:0]
-	for _, e := range hc.Entries {
+	for i := range hc.Entries {
+		e := &hc.Entries[i]
 		if _, drop := targets[normalizeURL(e.URL)]; drop {
 			continue
 		}
-		kept = append(kept, e)
+		kept = append(kept, *e)
 	}
 	dropped := len(hc.Entries) - len(kept)
 	hc.Entries = kept

--- a/internal/pruner/pruner.go
+++ b/internal/pruner/pruner.go
@@ -1,0 +1,219 @@
+// Package pruner owns the removal of README entries by health status.
+//
+// Why it exists: maintenance regularly produces a list of archived/stale
+// projects (see scorer + cache). Pruner is the seam that translates that list
+// into a concrete edit of README.md and config/health_cache.yaml, so the README
+// stays in lockstep with the cache instead of drifting via ad-hoc edits.
+package pruner
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/veggiemonk/awesome-docker/internal/cache"
+	"github.com/veggiemonk/awesome-docker/internal/parser"
+)
+
+// Removed describes a single entry removed from the README.
+type Removed struct {
+	URL    string
+	Name   string
+	Status string
+	Line   int
+}
+
+// Result summarizes a prune run.
+type Result struct {
+	Removed []Removed
+	// URLs in the target set that didn't appear in the README (already gone,
+	// non-GitHub indirection, or URL drift between cache and README).
+	NotFound []string
+}
+
+// TargetURLs returns the URL set selected by the given statuses from the cache.
+func TargetURLs(hc *cache.HealthCache, statuses []string) map[string]cache.HealthEntry {
+	want := make(map[string]bool, len(statuses))
+	for _, s := range statuses {
+		want[strings.TrimSpace(strings.ToLower(s))] = true
+	}
+	out := make(map[string]cache.HealthEntry)
+	for _, e := range hc.Entries {
+		if want[strings.ToLower(e.Status)] {
+			out[normalizeURL(e.URL)] = e
+		}
+	}
+	return out
+}
+
+// PruneREADME removes lines whose entry URL is in targets and writes the
+// result back to path. If dryRun is true, the file is not modified.
+func PruneREADME(path string, targets map[string]cache.HealthEntry, dryRun bool) (Result, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return Result{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	lines, err := readLines(f)
+	f.Close()
+	if err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var (
+		kept    = make([]string, 0, len(lines))
+		removed []Removed
+		hit     = make(map[string]bool, len(targets))
+	)
+
+	for i, line := range lines {
+		entry, perr := parser.ParseEntry(line, i+1)
+		if perr != nil {
+			kept = append(kept, line)
+			continue
+		}
+		key := normalizeURL(entry.URL)
+		meta, ok := targets[key]
+		if !ok {
+			kept = append(kept, line)
+			continue
+		}
+		hit[key] = true
+		removed = append(removed, Removed{
+			URL:    entry.URL,
+			Name:   entry.Name,
+			Status: meta.Status,
+			Line:   i + 1,
+		})
+	}
+
+	res := Result{Removed: removed}
+	for k := range targets {
+		if !hit[k] {
+			res.NotFound = append(res.NotFound, targets[k].URL)
+		}
+	}
+	sort.Strings(res.NotFound)
+
+	if dryRun || len(removed) == 0 {
+		return res, nil
+	}
+
+	if err := writeLines(path, kept); err != nil {
+		return res, fmt.Errorf("write %s: %w", path, err)
+	}
+	return res, nil
+}
+
+// PruneCache drops entries whose normalized URL is in targets and writes the
+// cache back to path. Safe to call when len(targets) == 0 (no-op).
+func PruneCache(path string, hc *cache.HealthCache, targets map[string]cache.HealthEntry, dryRun bool) (int, error) {
+	if len(targets) == 0 {
+		return 0, nil
+	}
+	kept := hc.Entries[:0]
+	for _, e := range hc.Entries {
+		if _, drop := targets[normalizeURL(e.URL)]; drop {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	dropped := len(hc.Entries) - len(kept)
+	hc.Entries = kept
+	if dryRun || dropped == 0 {
+		return dropped, nil
+	}
+	if err := cache.SaveHealthCache(path, hc); err != nil {
+		return dropped, err
+	}
+	return dropped, nil
+}
+
+// reportSectionRe matches markdown health-report section headings:
+//
+//	## Archived (should mark :skull:)
+//	## Stale (2+ years inactive)
+//	## Inactive (1-2 years)
+var reportSectionRe = regexp.MustCompile(`(?i)^##\s+(archived|stale|inactive|dead|healthy)\b`)
+
+// reportEntryRe matches: "- [name](url) - Stars: N - Last push: YYYY-MM-DD"
+var reportEntryRe = regexp.MustCompile(`^-\s+\[([^\]]+)\]\((https?://[^)]+)\)`)
+
+// TargetsFromReport parses a markdown health report (same format as the
+// `report` subcommand emits) and returns the URL set whose section heading
+// matches one of the given statuses.
+func TargetsFromReport(r io.Reader, statuses []string) (map[string]cache.HealthEntry, error) {
+	want := make(map[string]bool, len(statuses))
+	for _, s := range statuses {
+		want[strings.TrimSpace(strings.ToLower(s))] = true
+	}
+	out := make(map[string]cache.HealthEntry)
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var current string
+	for sc.Scan() {
+		line := sc.Text()
+		if m := reportSectionRe.FindStringSubmatch(line); m != nil {
+			current = strings.ToLower(m[1])
+			continue
+		}
+		if !want[current] {
+			continue
+		}
+		if m := reportEntryRe.FindStringSubmatch(line); m != nil {
+			url := strings.TrimSpace(m[2])
+			out[normalizeURL(url)] = cache.HealthEntry{
+				URL:    url,
+				Name:   m[1],
+				Status: current,
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func normalizeURL(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimSuffix(u, "/")
+	u = strings.ToLower(u)
+	return u
+}
+
+func readLines(r *os.File) ([]string, error) {
+	var lines []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}
+
+func writeLines(path string, lines []string) error {
+	out, err := os.Create(path) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	w := bufio.NewWriter(out)
+	for i, line := range lines {
+		if _, err := w.WriteString(line); err != nil {
+			return err
+		}
+		if i < len(lines)-1 {
+			if err := w.WriteByte('\n'); err != nil {
+				return err
+			}
+		}
+	}
+	if err := w.WriteByte('\n'); err != nil {
+		return err
+	}
+	return w.Flush()
+}

--- a/internal/pruner/pruner_test.go
+++ b/internal/pruner/pruner_test.go
@@ -1,0 +1,173 @@
+package pruner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/veggiemonk/awesome-docker/internal/cache"
+)
+
+func TestTargetURLs(t *testing.T) {
+	hc := &cache.HealthCache{Entries: []cache.HealthEntry{
+		{URL: "https://github.com/A/x", Status: "archived"},
+		{URL: "https://github.com/B/y", Status: "stale"},
+		{URL: "https://github.com/C/z", Status: "healthy"},
+		{URL: "https://github.com/D/w", Status: "inactive"},
+	}}
+	got := TargetURLs(hc, []string{"archived", "stale"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 targets, got %d", len(got))
+	}
+	if _, ok := got["https://github.com/a/x"]; !ok {
+		t.Errorf("expected lowercased URL key for archived entry")
+	}
+}
+
+func TestTargetsFromReport(t *testing.T) {
+	r := strings.NewReader(`# Health Report
+
+## Summary
+
+- Stale (2+ years): 2
+
+## Archived (should mark :skull:)
+
+- [a/keep](https://github.com/A/Keep) - Stars: 1 - Last push: 2024-01-01
+
+## Stale (2+ years inactive)
+
+- [b/drop](https://github.com/b/drop) - Stars: 2 - Last push: 2020-01-01
+
+## Inactive (1-2 years)
+
+- [c/skip](https://github.com/c/skip) - Stars: 3 - Last push: 2025-01-01
+`)
+	targets, err := TargetsFromReport(r, []string{"archived", "stale"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("want 2, got %d: %v", len(targets), targets)
+	}
+	if _, ok := targets["https://github.com/a/keep"]; !ok {
+		t.Errorf("missing archived entry (case-insensitive)")
+	}
+	if _, ok := targets["https://github.com/b/drop"]; !ok {
+		t.Errorf("missing stale entry")
+	}
+	if _, ok := targets["https://github.com/c/skip"]; ok {
+		t.Errorf("inactive entry should not have been picked up")
+	}
+}
+
+func TestPruneREADME(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "README.md")
+	content := `# Header
+
+## Tools
+
+- [keep](https://github.com/keep/me) - Healthy project.
+- [drop](https://github.com/drop/me) - Stale project.
+- [also-keep](https://github.com/also/keep) - Another one.
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := map[string]cache.HealthEntry{
+		"https://github.com/drop/me": {URL: "https://github.com/drop/me", Status: "stale"},
+	}
+	res, err := PruneREADME(path, targets, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Removed) != 1 {
+		t.Fatalf("want 1 removed, got %d", len(res.Removed))
+	}
+	if res.Removed[0].URL != "https://github.com/drop/me" {
+		t.Errorf("unexpected removed URL: %s", res.Removed[0].URL)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "drop/me") {
+		t.Errorf("expected drop/me to be removed from README, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "keep/me") || !strings.Contains(string(out), "also/keep") {
+		t.Errorf("expected other entries to be preserved, got:\n%s", out)
+	}
+}
+
+func TestPruneREADMEDryRun(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "README.md")
+	content := "## X\n\n- [drop](https://github.com/drop/me) - Stale.\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	targets := map[string]cache.HealthEntry{
+		"https://github.com/drop/me": {URL: "https://github.com/drop/me", Status: "stale"},
+	}
+	res, err := PruneREADME(path, targets, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Removed) != 1 {
+		t.Fatalf("want 1 removed (preview), got %d", len(res.Removed))
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != content {
+		t.Errorf("dry-run modified file: %q", got)
+	}
+}
+
+func TestPruneREADMENotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(path, []byte("## X\n\n- [k](https://github.com/k/v) - Keep.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	targets := map[string]cache.HealthEntry{
+		"https://github.com/gone/missing": {URL: "https://github.com/gone/missing", Status: "stale"},
+	}
+	res, err := PruneREADME(path, targets, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("want 0 removed, got %d", len(res.Removed))
+	}
+	if len(res.NotFound) != 1 || res.NotFound[0] != "https://github.com/gone/missing" {
+		t.Errorf("want gone/missing in NotFound, got %v", res.NotFound)
+	}
+}
+
+func TestPruneCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.yaml")
+	hc := &cache.HealthCache{Entries: []cache.HealthEntry{
+		{URL: "https://github.com/a/keep", Status: "healthy"},
+		{URL: "https://github.com/b/drop", Status: "stale"},
+	}}
+	if err := cache.SaveHealthCache(path, hc); err != nil {
+		t.Fatal(err)
+	}
+	targets := map[string]cache.HealthEntry{
+		"https://github.com/b/drop": {URL: "https://github.com/b/drop", Status: "stale"},
+	}
+	n, err := PruneCache(path, hc, targets, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("want 1 dropped, got %d", n)
+	}
+	if len(hc.Entries) != 1 || hc.Entries[0].URL != "https://github.com/a/keep" {
+		t.Errorf("unexpected remaining entries: %v", hc.Entries)
+	}
+}

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -23,15 +23,15 @@ const (
 
 // ScoredEntry is a repo with its computed health status.
 type ScoredEntry struct {
+	LastPush    time.Time
 	URL         string
 	Name        string
 	Status      Status
+	Category    string
+	Description string
 	Stars       int
 	Forks       int
 	HasLicense  bool
-	LastPush    time.Time
-	Category    string
-	Description string
 }
 
 // ReportSummary contains grouped status counts.
@@ -46,10 +46,10 @@ type ReportSummary struct {
 // ReportData is the full machine-readable report model.
 type ReportData struct {
 	GeneratedAt time.Time                `json:"generated_at"`
-	Total       int                      `json:"total"`
-	Summary     ReportSummary            `json:"summary"`
-	Entries     []ScoredEntry            `json:"entries"`
 	ByStatus    map[Status][]ScoredEntry `json:"by_status"`
+	Entries     []ScoredEntry            `json:"entries"`
+	Summary     ReportSummary            `json:"summary"`
+	Total       int                      `json:"total"`
 }
 
 // Score computes the health status of a GitHub repo.
@@ -94,7 +94,8 @@ func ScoreAll(infos []checker.RepoInfo) []ScoredEntry {
 func ToCacheEntries(scored []ScoredEntry) []cache.HealthEntry {
 	entries := make([]cache.HealthEntry, len(scored))
 	now := time.Now().UTC()
-	for i, s := range scored {
+	for i := range scored {
+		s := &scored[i]
 		entries[i] = cache.HealthEntry{
 			URL:         s.URL,
 			Name:        s.Name,
@@ -135,7 +136,8 @@ func GenerateReport(scored []ScoredEntry) string {
 			return
 		}
 		fmt.Fprintf(&b, "## %s\n\n", title)
-		for _, e := range entries {
+		for i := range entries {
+			e := &entries[i]
 			fmt.Fprintf(&b, "- [%s](%s) - Stars: %d - Last push: %s\n",
 				e.Name, e.URL, e.Stars, e.LastPush.Format("2006-01-02"))
 		}
@@ -152,8 +154,9 @@ func GenerateReport(scored []ScoredEntry) string {
 // BuildReportData returns full report data for machine-readable and markdown rendering.
 func BuildReportData(scored []ScoredEntry) ReportData {
 	groups := map[Status][]ScoredEntry{}
-	for _, s := range scored {
-		groups[s.Status] = append(groups[s.Status], s)
+	for i := range scored {
+		s := &scored[i]
+		groups[s.Status] = append(groups[s.Status], *s)
 	}
 
 	return ReportData{

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -86,7 +86,7 @@ func TestGenerateReport(t *testing.T) {
 
 func TestGenerateReportShowsAllEntries(t *testing.T) {
 	var results []ScoredEntry
-	for i := 0; i < 55; i++ {
+	for i := range 55 {
 		results = append(results, ScoredEntry{
 			URL:      fmt.Sprintf("https://github.com/stale/%d", i),
 			Name:     fmt.Sprintf("stale/%d", i),

--- a/internal/scorer/scorer_test.go
+++ b/internal/scorer/scorer_test.go
@@ -70,7 +70,13 @@ func TestGenerateReport(t *testing.T) {
 	results := []ScoredEntry{
 		{URL: "https://github.com/a/a", Name: "a/a", Status: StatusHealthy, Stars: 100, LastPush: time.Now()},
 		{URL: "https://github.com/b/b", Name: "b/b", Status: StatusArchived, Stars: 50, LastPush: time.Now()},
-		{URL: "https://github.com/c/c", Name: "c/c", Status: StatusStale, Stars: 10, LastPush: time.Now().AddDate(-3, 0, 0)},
+		{
+			URL:      "https://github.com/c/c",
+			Name:     "c/c",
+			Status:   StatusStale,
+			Stars:    10,
+			LastPush: time.Now().AddDate(-3, 0, 0),
+		},
 	}
 	report := GenerateReport(results)
 	if !strings.Contains(report, "Healthy: 1") {
@@ -85,8 +91,9 @@ func TestGenerateReport(t *testing.T) {
 }
 
 func TestGenerateReportShowsAllEntries(t *testing.T) {
-	var results []ScoredEntry
-	for i := range 55 {
+	const entryCount = 55
+	results := make([]ScoredEntry, 0, entryCount)
+	for i := range entryCount {
 		results = append(results, ScoredEntry{
 			URL:      fmt.Sprintf("https://github.com/stale/%d", i),
 			Name:     fmt.Sprintf("stale/%d", i),
@@ -100,7 +107,7 @@ func TestGenerateReportShowsAllEntries(t *testing.T) {
 	if strings.Contains(report, "... and") {
 		t.Fatal("report should not be truncated")
 	}
-	if !strings.Contains(report, "stale/54") {
+	if !strings.Contains(report, fmt.Sprintf("stale/%d", entryCount-1)) {
 		t.Fatal("report should contain all entries")
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
@@ -19,25 +21,25 @@ const (
 	panelList
 )
 
-const entryHeight = 5 // lines rendered per entry in the list panel
-const scrollOff = 4   // minimum lines/entries kept visible above and below cursor
+const (
+	entryHeight = 5 // lines rendered per entry in the list panel
+	scrollOff   = 4 // minimum lines/entries kept visible above and below cursor
+)
 
 // Model is the top-level Bubbletea model.
 type Model struct {
-	roots    []*TreeNode
-	flatTree []FlatNode
-
+	filterText     string
+	roots          []*TreeNode
+	flatTree       []FlatNode
+	currentEntries []cache.HealthEntry
 	activePanel    panel
 	treeCursor     int
 	treeOffset     int
 	listCursor     int
 	listOffset     int
-	currentEntries []cache.HealthEntry
-
-	filtering  bool
-	filterText string
-
-	width, height int
+	width          int
+	height         int
+	filtering      bool
 }
 
 // New creates a new Model from health cache entries.
@@ -135,11 +137,13 @@ func (m *Model) applyFilter() {
 	query := strings.ToLower(m.filterText)
 	var filtered []cache.HealthEntry
 	for _, root := range m.roots {
-		for _, e := range root.AllEntries() {
+		entries := root.AllEntries()
+		for i := range entries {
+			e := &entries[i]
 			if strings.Contains(strings.ToLower(e.Name), query) ||
 				strings.Contains(strings.ToLower(e.Description), query) ||
 				strings.Contains(strings.ToLower(e.Category), query) {
-				filtered = append(filtered, e)
+				filtered = append(filtered, *e)
 			}
 		}
 	}
@@ -242,7 +246,8 @@ func (m *Model) adjustTreeScroll() {
 func (m Model) treePanelHeight() int {
 	h := max(
 		// header, footer, borders, title
-		m.height-6, 1)
+		m.height-6, 1,
+	)
 	return h
 }
 
@@ -467,7 +472,8 @@ func (m Model) renderList(width, height int) string {
 		statsW := lipgloss.Width(stats)
 		maxName := max(
 			// 2 for minimum gap
-			safeWidth-statsW-2, 4)
+			safeWidth-statsW-2, 4,
+		)
 		if lipgloss.Width(name) > maxName {
 			name = truncateToWidth(name, maxName-1) + "…"
 		}
@@ -494,7 +500,7 @@ func (m Model) renderList(width, height int) string {
 		statusStr := statusStyle(e.Status).Render(e.Status)
 		lastPush := ""
 		if !e.LastPush.IsZero() {
-			lastPush = fmt.Sprintf("  Last push: %s", e.LastPush.Format("2006-01-02"))
+			lastPush = "  Last push: " + e.LastPush.Format("2006-01-02")
 		}
 		line4 := statusStr + entryDescStyle.Render(lastPush)
 
@@ -535,14 +541,16 @@ type openURLMsg struct{ err error }
 
 func openURL(url string) tea.Cmd {
 	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		var cmd *exec.Cmd
 		switch runtime.GOOS {
 		case "darwin":
-			cmd = exec.Command("open", url)
+			cmd = exec.CommandContext(ctx, "open", url)
 		case "windows":
-			cmd = exec.Command("cmd", "/c", "start", url)
+			cmd = exec.CommandContext(ctx, "cmd", "/c", "start", url)
 		default:
-			cmd = exec.Command("xdg-open", url)
+			cmd = exec.CommandContext(ctx, "xdg-open", url)
 		}
 		return openURLMsg{err: cmd.Run()}
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -176,10 +176,7 @@ func (m Model) handleTreeKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.updateCurrentEntries()
 		}
 	case "ctrl+d", "pgdown":
-		half := m.treePanelHeight() / 2
-		if half < 1 {
-			half = 1
-		}
+		half := max(m.treePanelHeight()/2, 1)
 		m.treeCursor += half
 		if m.treeCursor >= len(m.flatTree) {
 			m.treeCursor = len(m.flatTree) - 1
@@ -187,10 +184,7 @@ func (m Model) handleTreeKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.adjustTreeScroll()
 		m.updateCurrentEntries()
 	case "ctrl+u", "pgup":
-		half := m.treePanelHeight() / 2
-		if half < 1 {
-			half = 1
-		}
+		half := max(m.treePanelHeight()/2, 1)
 		m.treeCursor -= half
 		if m.treeCursor < 0 {
 			m.treeCursor = 0
@@ -233,10 +227,7 @@ func (m Model) handleTreeKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) adjustTreeScroll() {
 	visible := m.treePanelHeight()
-	off := scrollOff
-	if off > visible/2 {
-		off = visible / 2
-	}
+	off := min(scrollOff, visible/2)
 	if m.treeCursor < m.treeOffset+off {
 		m.treeOffset = m.treeCursor - off
 	}
@@ -249,10 +240,9 @@ func (m *Model) adjustTreeScroll() {
 }
 
 func (m Model) treePanelHeight() int {
-	h := m.height - 6 // header, footer, borders, title
-	if h < 1 {
-		h = 1
-	}
+	h := max(
+		// header, footer, borders, title
+		m.height-6, 1)
 	return h
 }
 
@@ -269,20 +259,14 @@ func (m Model) handleListKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.adjustListScroll()
 		}
 	case "ctrl+d", "pgdown":
-		half := m.visibleListEntries() / 2
-		if half < 1 {
-			half = 1
-		}
+		half := max(m.visibleListEntries()/2, 1)
 		m.listCursor += half
 		if m.listCursor >= len(m.currentEntries) {
 			m.listCursor = len(m.currentEntries) - 1
 		}
 		m.adjustListScroll()
 	case "ctrl+u", "pgup":
-		half := m.visibleListEntries() / 2
-		if half < 1 {
-			half = 1
-		}
+		half := max(m.visibleListEntries()/2, 1)
 		m.listCursor -= half
 		if m.listCursor < 0 {
 			m.listCursor = 0
@@ -328,10 +312,7 @@ func (m Model) visibleListEntries() int {
 
 func (m *Model) adjustListScroll() {
 	visible := m.visibleListEntries()
-	off := scrollOff
-	if off > visible/2 {
-		off = visible / 2
-	}
+	off := min(scrollOff, visible/2)
 	if m.listCursor < m.listOffset+off {
 		m.listOffset = m.listCursor - off
 	}
@@ -345,10 +326,7 @@ func (m *Model) adjustListScroll() {
 
 func (m Model) listPanelHeight() int {
 	// height minus header, footer, borders
-	h := m.height - 4
-	if h < 1 {
-		h = 1
-	}
+	h := max(m.height-4, 1)
 	return h
 }
 
@@ -406,10 +384,7 @@ func (m Model) renderTree(width, height int) string {
 	b.WriteString("\n\n")
 
 	linesUsed := 2
-	end := m.treeOffset + height - 2
-	if end > len(m.flatTree) {
-		end = len(m.flatTree)
-	}
+	end := min(m.treeOffset+height-2, len(m.flatTree))
 	for i := m.treeOffset; i < end; i++ {
 		fn := m.flatTree[i]
 		if linesUsed >= height {
@@ -466,16 +441,10 @@ func (m Model) renderList(width, height int) string {
 
 	linesUsed := 2
 
-	visible := (height - 2) / entryHeight
-	if visible < 1 {
-		visible = 1
-	}
+	visible := max((height-2)/entryHeight, 1)
 
 	start := m.listOffset
-	end := start + visible
-	if end > len(m.currentEntries) {
-		end = len(m.currentEntries)
-	}
+	end := min(start+visible, len(m.currentEntries))
 
 	for idx := start; idx < end; idx++ {
 		if linesUsed+entryHeight > height {
@@ -496,19 +465,15 @@ func (m Model) renderList(width, height int) string {
 		}
 		name := e.Name
 		statsW := lipgloss.Width(stats)
-		maxName := safeWidth - statsW - 2 // 2 for minimum gap
-		if maxName < 4 {
-			maxName = 4
-		}
+		maxName := max(
+			// 2 for minimum gap
+			safeWidth-statsW-2, 4)
 		if lipgloss.Width(name) > maxName {
 			name = truncateToWidth(name, maxName-1) + "…"
 		}
 		nameStr := entryNameStyle.Render(name)
 		statsStr := entryDescStyle.Render(stats)
-		padding := safeWidth - lipgloss.Width(nameStr) - lipgloss.Width(statsStr)
-		if padding < 1 {
-			padding = 1
-		}
+		padding := max(safeWidth-lipgloss.Width(nameStr)-lipgloss.Width(statsStr), 1)
 		line1 := nameStr + strings.Repeat(" ", padding) + statsStr
 
 		// Line 2: URL
@@ -534,10 +499,7 @@ func (m Model) renderList(width, height int) string {
 		line4 := statusStr + entryDescStyle.Render(lastPush)
 
 		// Line 5: separator
-		sepWidth := safeWidth
-		if sepWidth < 1 {
-			sepWidth = 1
-		}
+		sepWidth := max(safeWidth, 1)
 		line5 := entryDescStyle.Render(strings.Repeat("─", sepWidth))
 
 		entry := fmt.Sprintf("%s\n%s\n%s\n%s\n%s", line1, line2, line3, line4, line5)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -13,8 +13,11 @@ var (
 				BorderForeground(lipgloss.Color("#555555"))
 
 	// Tree styles
-	treeSelectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FF79C6")).Background(lipgloss.Color("#3B2D50"))
-	treeNormalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#CCCCCC"))
+	treeSelectedStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#FF79C6")).
+				Background(lipgloss.Color("#3B2D50"))
+	treeNormalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#CCCCCC"))
 
 	// Entry styles
 	entryNameStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#50FA7B"))

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -9,11 +9,11 @@ import (
 
 // TreeNode represents a node in the category tree.
 type TreeNode struct {
-	Name     string       // display name (leaf segment, e.g. "Networking")
-	Path     string       // full path (e.g. "Container Operations > Networking")
+	Name     string
+	Path     string
 	Children []*TreeNode
-	Expanded bool
 	Entries  []cache.HealthEntry
+	Expanded bool
 }
 
 // FlatNode is a visible tree node with its indentation depth.
@@ -51,14 +51,15 @@ func BuildTree(entries []cache.HealthEntry) []*TreeNode {
 	root := &TreeNode{Name: "root"}
 	nodeMap := map[string]*TreeNode{}
 
-	for _, e := range entries {
+	for i := range entries {
+		e := &entries[i]
 		cat := e.Category
 		if cat == "" {
 			cat = "Uncategorized"
 		}
 
 		node := ensureNode(root, nodeMap, cat)
-		node.Entries = append(node.Entries, e)
+		node.Entries = append(node.Entries, *e)
 	}
 
 	// Sort children at every level

--- a/internal/tui/tree_test.go
+++ b/internal/tui/tree_test.go
@@ -11,7 +11,12 @@ func TestBuildTree(t *testing.T) {
 		{URL: "https://github.com/a/b", Name: "a/b", Category: "Projects > Networking", Description: "desc1"},
 		{URL: "https://github.com/c/d", Name: "c/d", Category: "Projects > Networking", Description: "desc2"},
 		{URL: "https://github.com/e/f", Name: "e/f", Category: "Projects > Security", Description: "desc3"},
-		{URL: "https://github.com/g/h", Name: "g/h", Category: "Docker Images > Base Tools", Description: "desc4"},
+		{
+			URL:         "https://github.com/g/h",
+			Name:        "g/h",
+			Category:    "Docker Images > Base Tools",
+			Description: "desc4",
+		},
 		{URL: "https://github.com/i/j", Name: "i/j", Category: "", Description: "no category"},
 	}
 


### PR DESCRIPTION
Add a new `awesome-docker prune` subcommand that removes README entries whose repository health status matches a configurable set (default: archived,stale). URLs are read from the local health cache, or from a markdown report file via --from-report when the cache is outdated.

Apply it against the issue #1439 health report to remove 5 entries that survived the recent reorg: stitchocker, docker-consul, blockbridge-docker-volume, docker-explorer, dockdash.

Add google/container-explorer in the Security section as the actively maintained successor to the now-archived google/docker-explorer.


# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to ____."*

If the blank doesn't contain **Docker, container, image, registry, Dockerfile, Compose, Swarm, BuildKit, or OCI**, it probably doesn't belong here.

What changed and why:

