### PR TITLE
Add InfraCanvas to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Monitor Docker hosts, containers, and the services running inside them. Self-hos
 - [Drydock](https://github.com/CodesWhat/drydock) - Container update monitoring with web dashboard, 23 registry providers, 20 notification triggers, and distributed agent architecture.
 - [Dynatrace](https://docs.dynatrace.com/docs/observe/infrastructure-observability/container-platform-monitoring) - :yen: Monitor containerized applications without installing agents or modifying your Run commands.
 - [Grafana Docker Dashboard Template](https://grafana.com/grafana/dashboards/179-docker-prometheus-monitoring/) - A template for your Docker, Grafana and Prometheus stack.
+- [InfraCanvas](https://github.com/bytestrix/InfraCanvas) - Live visual map of containers, pods, volumes, and networks on any Linux server. Single binary, WebSocket-powered live updates.
 - [Maintenant](https://github.com/kolapsis/maintenant) - Self-discovering infrastructure monitoring for Docker and Kubernetes. Auto-detects containers via labels, with endpoint monitoring, heartbeats, TLS certificates, resource metrics, update intelligence, and a built-in status page. Single binary with embedded SPA.
 - [Middleware](https://middleware.io/) - :yen: Monitor Docker hosts, containers, logs, and application performance from a unified observability platform.
 - [Site24x7](https://www.site24x7.com/docker-monitoring.html) - :yen: Docker Monitoring for DevOps and IT, SaaS Pay-per-Host model.


### PR DESCRIPTION
**InfraCanvas** is a single Go binary that discovers and visualizes every container, volume, network, and deployment on a Linux host — live in your browser.

- **Source:** https://github.com/bytestrix/InfraCanvas
- **License:** AGPL-3.0
- **Install:** `curl -fsSL https://github.com/bytestrix/InfraCanvas/releases/latest/download/install.sh | bash`
- Docker + Kubernetes support
- Real-time WebSocket updates, no polling
- No external services required
