### PR TITLE
Add localdevstack to Development Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Self-hosted CI engines, build accelerators, and hosted services that target Dock
 - [Lando](https://github.com/lando/lando) - Lando is for developers who want to quickly specify and painlessly spin up the services and tools needed to develop their projects.
 - [uniget](https://github.com/uniget-org/cli) - Uni(versal)get, the installer and updater for container tools and beyond (formerly docker-setup).
 - [Zsh-in-Docker](https://github.com/deluan/zsh-in-docker) - Install Zsh, Oh-My-Zsh and plugins inside a Docker container with one line!.
+- [localdevstack](https://github.com/krishgok/localdevstack) - Spin up a production-shaped local stack in 30 seconds. One command generates a Dockerised service + database + hot-reload. Coverage for 9 languages, 8 databases.
 
 ### Serverless
 

--- a/README.md
+++ b/README.md
@@ -467,9 +467,10 @@ Self-hosted CI engines, build accelerators, and hosted services that target Dock
 - [Gebug](https://github.com/moshebe/gebug) - A tool that makes debugging of Dockerized Go applications super easy by enabling Debugger and Hot-Reload features, seamlessly.
 - [HarborPilot](https://github.com/potterwhite/HarborPilot) - Automated multi-platform Docker image builder for embedded Linux development (RK3588, RV1126, RK3568). Features three-layer config inheritance, PORT_SLOT-based port allocation, and cross-version Ubuntu support (20.04/22.04/24.04).
 - [Lando](https://github.com/lando/lando) - Lando is for developers who want to quickly specify and painlessly spin up the services and tools needed to develop their projects.
+- [localdevstack](https://github.com/krishgok/localdevstack) - Spin up a production-shaped local stack in 30 seconds. One command generates a Dockerised service + database + hot-reload. Coverage for 9 languages, 8 databases.
 - [uniget](https://github.com/uniget-org/cli) - Uni(versal)get, the installer and updater for container tools and beyond (formerly docker-setup).
 - [Zsh-in-Docker](https://github.com/deluan/zsh-in-docker) - Install Zsh, Oh-My-Zsh and plugins inside a Docker container with one line!.
-- [localdevstack](https://github.com/krishgok/localdevstack) - Spin up a production-shaped local stack in 30 seconds. One command generates a Dockerised service + database + hot-reload. Coverage for 9 languages, 8 databases.
+
 
 ### Serverless
 


### PR DESCRIPTION
This project exists to generate a complete "docker compose based" local dev stack - service container + database container + Dockerfile.dev with the language-appropriate hot-reload tool - from a single command.  

Every invocation outputs two Docker artifacts plus optional sidecars:
- Dockerfile.dev — single-stage, hot-reload baked in
- docker-compose.yml — service container + database container + (optional) migrate: job + (optional) companion
  services (mailhog, minio)

LocalDevStack is a one-command scaffold for a Docker-Compose local dev stack (service + database + hot-reload) with coverage for 9 languages and 8 databases with optional companion components.

Demo - https://github.com/krishgok/localdevstack/blob/main/docs/assets/demo.gif

