### PR TITLE
Add Gantry to Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Native desktop applications for managing and monitoring docker hosts and cluster
 
 - [Docker DB Manager](https://github.com/AbianS/docker-db-manager) - Desktop app for managing Docker database containers with visual interface and one-click operations.
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) - Official native app. Only for Windows and MacOS.
+- [Gantry](https://github.com/getgantry/gantry) - Native macOS app (SwiftUI, no Electron) for managing and monitoring Docker hosts, local and over SSH: fleet dashboard, live logs and stats, exec terminal, file browser, and a bundled MCP server for AI agents.
 - [Simple Docker UI](https://github.com/felixgborrego/simple-docker-ui) - Built on Electron.
 - [Stevedore](https://github.com/slonopotamus/stevedore) - Good Docker Desktop replacement for Windows. Both Linux and Windows Containers are supported. [slonopotamus](https://github.com/slonopotamus).
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Native desktop applications for managing and monitoring docker hosts and cluster
 
 - [Docker DB Manager](https://github.com/AbianS/docker-db-manager) - Desktop app for managing Docker database containers with visual interface and one-click operations.
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) - Official native app. Only for Windows and MacOS.
-- [Gantry](https://github.com/getgantry/gantry) - Native macOS app (SwiftUI, no Electron) for managing and monitoring Docker hosts, local and over SSH: fleet dashboard, live logs and stats, exec terminal, file browser, and a bundled MCP server for AI agents.
+- [Gantry (Desktop)](https://github.com/getgantry/gantry) - Native macOS app (SwiftUI, no Electron) for managing and monitoring Docker hosts, local and over SSH: fleet dashboard, live logs and stats, exec terminal, file browser, and a bundled MCP server for AI agents.
 - [Simple Docker UI](https://github.com/felixgborrego/simple-docker-ui) - Built on Electron.
 - [Stevedore](https://github.com/slonopotamus/stevedore) - Good Docker Desktop replacement for Windows. Both Linux and Windows Containers are supported. [slonopotamus](https://github.com/slonopotamus).
 


### PR DESCRIPTION
- [x] I HAVE READ .github/CONTRIBUTING.md

This project exists to **manage and monitor Docker hosts** — it is a native macOS client for the Docker Engine API.

What changed and why:

Added [Gantry](https://github.com/getgantry/gantry) to User Interfaces → Desktop (alphabetical order).

Gantry is a free, MIT-licensed native macOS app (SwiftUI, no Electron) for managing Docker: containers, images, volumes, networks, live logs, stats charts, exec terminal and a container file browser. It connects to remote hosts exactly like `docker -H ssh://` (an SSH channel running `docker system dial-stdio`), shows all hosts on one fleet dashboard, and bundles an MCP server so AI agents can manage the same hosts.