### PR TITLE
Add Watchtower (maintained fork) to CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Self-hosted CI engines, build accelerators, and hosted services that target Dock
 - [Skipper](https://github.com/Stratoscale/skipper) - Easily dockerize your Git repository.
 - [Tekton CD](https://tekton.dev/) - A cloud-native pipeline resource.
 - [TravisCI](https://www.travis-ci.com/) - :yen: Hosted CI for GitHub projects with Docker support.
+- [Watchtower](https://github.com/openserbia/watchtower) - Automatically update running containers when a new image is pushed to the registry, recreating them with the same configuration.
 
 ### Development Environment
 


### PR DESCRIPTION
**What:** Adds **Watchtower** (`openserbia/watchtower`) to the **CI/CD** section.

**Why:** It's an actively maintained, drop-in fork of `containrrr/watchtower`, which was archived (read-only) on 2025-12-17 and previously removed from this list. Unlike the archived original, this fork builds against current Docker clients and works on Docker Engine 28/29.

**"for Docker" test:** Watchtower exists to watch the Docker daemon and recreate containers from updated images — remove Docker and the project has no reason to exist. ✅

Entry is placed alphabetically in CI/CD alongside the other image-update tools (Diun, dockcheck, Gantry); happy to move it if you prefer another section.

Disclosure: I'm the maintainer of this fork.
