### PR TITLE
Add compose-lint to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Container hardening, runtime security, policy, compliance, and forensics. Self-h
 - [buildcage](https://github.com/dash14/buildcage) - Restricts outbound network access during Docker builds to prevent supply chain attacks, working as a drop-in BuildKit remote driver for Docker Buildx, with ready-to-use GitHub Actions.
 - [CetusGuard](https://github.com/hectorm/cetusguard) - CetusGuard is a tool that protects the Docker daemon socket by filtering calls to its API endpoints.
 - [Checkov](https://github.com/bridgecrewio/checkov) - Static analysis for infrastructure as code manifests (Terraform, Kubernetes, Cloudformation, Helm, Dockerfile, Kustomize) find security misconfiguration and fix them.
+- [compose-lint](https://github.com/tmatens/compose-lint) - Lints Docker Compose files for security misconfigurations — privileged containers, unpinned images, Docker socket mounts, plaintext credentials — grounded in OWASP and the CIS Docker Benchmark.
 - [container-explorer](https://github.com/google/container-explorer) - Forensic utility to explore Docker and containerd container details from mounted disk images.
 - [Deepfence Threat Mapper](https://github.com/deepfence/ThreatMapper) - Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Den](https://github.com/us/den) - Self-hosted sandbox runtime for AI agents with Docker containers, security hardening, REST API and WebSocket support.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to ____."*

**This project exists to lint Docker Compose files for security misconfigurations.** Its object of work is the Compose file itself — take Docker away and it has no reason to exist.

What changed and why:

Adds [compose-lint](https://github.com/tmatens/compose-lint) to the **Security** section (alphabetical, between Checkov and container-explorer).

compose-lint is a static-analysis security linter for `docker-compose.yml` / `compose.yaml`. It catches privileged containers, missing `cap_drop`/`no-new-privileges`, host namespace sharing, wildcard port binds, unpinned images, Docker socket mounts, sensitive bind mounts, and plaintext credentials — every rule cites the OWASP Docker Security Cheat Sheet or the CIS Docker Benchmark, with specific fix guidance per finding.

Why Security rather than the Linter subsection: the Linter subsection sits under *Building Images* and is Dockerfile-oriented (Hadolint et al.); compose-lint targets runtime/deployment configuration and fits the same niche as Checkov and KICS, but specialized for Compose. Happy to move it if you prefer otherwise.

Quality signals:

- Active: released on [PyPI](https://pypi.org/project/compose-lint/) and [Docker Hub](https://hub.docker.com/r/composelint/compose-lint) (distroless, multi-arch, nonroot, Sigstore-signed, SLSA provenance), CI on Python 3.10–3.14.
- [OpenSSF Best Practices passing](https://www.bestpractices.dev/projects/12472) and OpenSSF Scorecard tracked.
- Ships a [*State of Docker Compose Security* report](https://github.com/tmatens/compose-lint/blob/main/docs/state-of-compose.md) from scanning 6,444 public Compose files: 91% of those that parse had at least one finding, 68% HIGH or CRITICAL.

Entry passes `make lint` locally (`OK: 0 warnings`): one GitHub link, one-sentence verb-first description, Docker connection explicit, alphabetical order preserved.