### PR TITLE
feat: add resq to category storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Container-aware reverse proxies, ingress, and TLS-terminating front-ends with au
 - [Netshare](https://github.com/ContainX/docker-volume-netshare) Docker NFS, AWS EFS, Ceph & Samba/CIFS Volume Plugin.
 - [portworx](https://portworx.com) - :yen: Decentralized storage solution for persistent, shared and replicated volumes.
 - [quobyte](https://www.quobyte.com/) - :yen: Fully fault-tolerant distributed file system with a docker volume driver.
-- [resq](https://github.com/mashb1t/resq) - Restic-powered Docker backups for volumes, databases, and .env files, both with/without stopping containers. Works with local, ssh, or any S3 compatible storage.
+- [resq](https://github.com/mashb1t/resq) - Restic-powered Docker backups for volumes, databases, and .env files, with or without stopping containers. Works with local, SSH, or any S3 compatible storage.
 - [REX-Ray](https://github.com/rexray/rexray) provides a vendor agnostic storage orchestration engine. The primary design goal is to provide persistent storage for Docker, Kubernetes, and Mesos.
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -303,11 +303,12 @@ Container-aware reverse proxies, ingress, and TLS-terminating front-ends with au
 
 ## Storage & Data
 
-- [Label Backup](https://github.com/resulgg/label-backup) - A lightweight, Docker-aware backup agent that automatically discovers and backs up containerized databases (PostgreSQL, MySQL, MongoDB, Redis) based on Docker labels. Supports local storage and S3-compatible destinations with flexible scheduling via cron expressions.
 - [Docker Volume Backup](https://github.com/offen/docker-volume-backup) Backup Docker volumes locally or to any S3 compatible storage.
+- [Label Backup](https://github.com/resulgg/label-backup) - A lightweight, Docker-aware backup agent that automatically discovers and backs up containerized databases (PostgreSQL, MySQL, MongoDB, Redis) based on Docker labels. Supports local storage and S3-compatible destinations with flexible scheduling via cron expressions.
 - [Netshare](https://github.com/ContainX/docker-volume-netshare) Docker NFS, AWS EFS, Ceph & Samba/CIFS Volume Plugin.
 - [portworx](https://portworx.com) - :yen: Decentralized storage solution for persistent, shared and replicated volumes.
 - [quobyte](https://www.quobyte.com/) - :yen: Fully fault-tolerant distributed file system with a docker volume driver.
+- [resq](https://github.com/mashb1t/resq) - Restic-powered Docker backups for volumes, databases, and .env files, both with/without stopping containers. Works with local, ssh, or any S3 compatible storage.
 - [REX-Ray](https://github.com/rexray/rexray) provides a vendor agnostic storage orchestration engine. The primary design goal is to provide persistent storage for Docker, Kubernetes, and Mesos.
 
 ## Observability


### PR DESCRIPTION
Resq is a direct improvement of https://github.com/offen/docker-volume-backup as it uses restic delta backups instead of full zip files every time, which massively saves backup storage.

Compared to https://github.com/resulgg/label-backup (already on our list) it is not a sidecar, but a standalone backup bash script, running on a central user-defined cron schedule instead of a label-defined per-container one.

Also cleanup entries to restore alphabetical sort order.

Happy to hear your opinion on this :)