### PR TITLE
Add Mooring to the list of Docker tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Self-hosted and managed cloud platforms (PaaS/CaaS, deployment automation). Comm
 - [Google Container Engine](https://docs.cloud.google.com/kubernetes-engine/docs) - :yen: Docker containers on Google Cloud Computing powered by [Kubernetes][kubernetes].
 - [Grafeas](https://github.com/grafeas/grafeas) - A common API for metadata about containers, from image and build details to security vulnerabilities.
 - [Mesosphere DC/OS Platform](https://d2iq.com/products/dcos) - :yen: Integrated platform for data and containers built on Apache Mesos.
+- [Mooring](https://github.com/daboss2003/mooring) - Security-first, self-hosted control plane for Docker that deploys multi-service Docker apps from one typed YAML with automatic HTTPS, monitoring, alerts, backups, Git deploys and self-healing, without Swarm or Kubernetes.
 - [OpenShift][openshift] - An open source PaaS built on [Kubernetes][kubernetes] and optimized for Dockerized app development and deployment by [Red Hat](https://www.redhat.com/en)
 - [Red Hat OpenShift Dedicated](https://www.redhat.com/en/technologies/cloud-computing/openshift/dedicated) - :yen: Fully-managed Red Hat® OpenShift® service on Amazon Web Services and Google Cloud.
 - [swarm-ansible](https://github.com/LombardiDaniel/swarm-ansible?tab=readme-ov-file) - Swarm-Ansible bootstraps a production-ready swarm cluster using ansible. Comes with tools to automate CI, help monitoring and traefik pre-configured for SSL certificates and simple-auth. Comes with a private registry and more!.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [X] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to deploy and manage multi-service Docker applications from a single typed YAML — a self-hosted control plane / PaaS for Docker that generates and owns the Compose file and Dockerfile, provisions HTTPS, and runs, monitors and self-heals containers, without Swarm or Kubernetes.."*

If the blank doesn't contain **Docker, container, image, registry, Dockerfile, Compose, Swarm, BuildKit, or OCI**, it probably doesn't belong here.

What changed and why: Adds one entry, Mooring (https://github.com/daboss2003/mooring — Go, Apache-2.0, latest release v0.4.6), to the Deployment & Platforms section in alphabetical order (between Mesosphere DC/OS Platform and OpenShift). No :yen: marker — it's free and open source.

