### PR TITLE
Add dockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [DockMate](https://github.com/shubh-io/dockmate) - Lightweight terminal-based Docker and Podman manager with a text-based user interface,.
 - [DockSTARTer](https://github.com/GhostWriters/DockSTARTer) - DockSTARTer helps you get started with home server apps running in Docker.
 - [DockTUI](https://github.com/strmax195-hue/docktui) - Fast, zero-dependency terminal dashboard for Docker and Compose.
+- [dockup](https://github.com/paulo-amaral/dockup) - TUI to install, harden and maintain container runtimes: Docker Engine + Compose v2, NVIDIA Container Toolkit, Podman and Apple container, with a CIS-inspired security audit.
 - [dprs](https://github.com/durableprogramming/dprs) - A developer-focused TUI for managing Docker containers with real-time log streaming and container management.
 - [dry](https://github.com/moncho/dry) - An interactive CLI for Docker containers.
 - [easydocker](https://github.com/joao-zanutto/easydocker) - A Terminal UI highly inpired by k9s levaraging beatiful BubbleTea graphics.


### PR DESCRIPTION
Adds [dockup](https://github.com/paulo-amaral/dockup) to Terminal UI.

dockup is a Bubble Tea TUI (MIT, Go) that installs, hardens and maintains container runtimes from one command: Docker Engine + Compose v2, NVIDIA Container Toolkit, Podman and Apple's container on macOS. It ships a read-only CIS-inspired security audit with `--format json` for CI gates, checksum-verified releases and an auto-generated VHS demo.

Entry follows the existing format and alphabetical order (between DockTUI and dprs).