### PR TITLE
Add Dofigen to Dockerfile list

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Minimal, hardened, or purpose-built container base images.
 
 - [Dockerfile Generator](https://github.com/ozankasikci/dockerfile-generator) `dfg` is both a Go library and an executable that produces valid Dockerfiles using various input channels.
 - [Dockershelf](https://github.com/Dockershelf/dockershelf) - A repository that serves as a collector for docker recipes that are universal, efficient and slim. Images are updated, tested and published daily via a Travis cron job.
+- [Dofigen](https://github.com/lenra-io/dofigen) - A Dockerfile generator using a simplified description in YAML or JSON format.
 - [Trsuted Builds](https://dockerfile.github.io/) - Trusted Automated Docker Builds. Dockerfile Project maintains a central repository of Dockerfile for various popular open source software services runnable on a Docker container.
 
 ### Linter


### PR DESCRIPTION
Added Dofigen to the list of Dockerfile generators.


# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [X] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to help creating advanced Dockerfile with a simplified syntax."*

If the blank doesn't contain **Docker, container, image, registry, Dockerfile, Compose, Swarm, BuildKit, or OCI**, it probably doesn't belong here.

What changed and why: Adding a new tool, Dofigen

