### PR TITLE
Add pglayers to Base Images section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Minimal, hardened, or purpose-built container base images.
 - [Chainguard Images](https://github.com/chainguard-images/images) - Minimal, signed, SBOM-attested container images built on Wolfi.
 - [distroless](https://github.com/GoogleContainerTools/distroless) - Language focused docker images, minus the operating system.
 - [melange](https://github.com/chainguard-dev/melange) - Build apk packages from declarative YAML for use with apko.
+- [pglayers](https://github.com/pglayers/pglayers) - Pre-built PostgreSQL extensions as composable Docker layers. 50+ extensions, ready-to-use combined images (full, Azure-compatible).
 - [Wolfi](https://github.com/wolfi-dev/os) - Undistro Linux designed for containers; glibc-based, signed, daily SBOMs.
 
 


### PR DESCRIPTION
Add [pglayers](https://github.com/pglayers/pglayers) - Pre-built PostgreSQL extensions as composable Docker layers. 50+ extensions, ready-to-use combined images (full, Azure-compatible).

Placed in **Base Images** as it is a purpose-built container image project focused on Docker layer composability for PostgreSQL extensions.