### PR TITLE
feat: add layerx to Terminal UI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [easydocker](https://github.com/joao-zanutto/easydocker) - A Terminal UI highly inpired by k9s levaraging beatiful BubbleTea graphics.
 - [goManageDocker](https://github.com/ajayd-san/gomanagedocker) - TUI tool to view and manage your docker objects blazingly fast with sensible keybindings, also supports VIM navigation out of the box.
 - [lazydocker](https://github.com/jesseduffield/lazydocker) - The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.
+- [layerx](https://github.com/deveshctl/layerx) - Inspect container image layers in a TUI — browse filesystem diffs, view file contents inline, sort by size, extract individual files, and gate CI on efficiency thresholds. Supports Docker, Podman, and OCI archives.
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) - A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.
 - [oxker](https://github.com/mrjackwills/oxker) - A simple tui to view & control docker containers.
 - [proco](https://github.com/shiwaforce/poco) - Proco will help you to organise and manage Docker, Docker-Compose, Kubernetes projects of any complexity using simple YAML config files to shorten the route from finding your project to initialising it in your local environment.

--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [dry](https://github.com/moncho/dry) - An interactive CLI for Docker containers.
 - [easydocker](https://github.com/joao-zanutto/easydocker) - A Terminal UI highly inpired by k9s levaraging beatiful BubbleTea graphics.
 - [goManageDocker](https://github.com/ajayd-san/gomanagedocker) - TUI tool to view and manage your docker objects blazingly fast with sensible keybindings, also supports VIM navigation out of the box.
-- [lazydocker](https://github.com/jesseduffield/lazydocker) - The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.
 - [layerx](https://github.com/deveshctl/layerx) - Inspect container image layers in a TUI — browse filesystem diffs, view file contents inline, sort by size, extract individual files, and gate CI on efficiency thresholds. Supports Docker, Podman, and OCI archives.
+- [lazydocker](https://github.com/jesseduffield/lazydocker) - The lazier way to manage everything docker. A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) - A interface for reading and filtering the logs output of Docker and Podman containers like [Dozzle](dozzle) but for the terminal with support for fuzzy find, regex and output coloring.
 - [oxker](https://github.com/mrjackwills/oxker) - A simple tui to view & control docker containers.
 - [proco](https://github.com/shiwaforce/poco) - Proco will help you to organise and manage Docker, Docker-Compose, Kubernetes projects of any complexity using simple YAML config files to shorten the route from finding your project to initialising it in your local environment.


### PR DESCRIPTION
- [x] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to ____."*

This project exists to inspect container image layers — browse filesystem diffs, view file contents inline, sort files by size, extract individual files, and gate CI on image efficiency thresholds.

What changed and why:

Added layerx to the Terminal section under User Interfaces. It is an image layer inspector with a two-panel TUI (layers on the left, live filetree on the right). Supports Docker, Podman, and OCI archives from a single static binary. Built in Go with bubbletea/lipgloss.

Placed alphabetically between lazydocker and lazyjournal.

## Scope

- [x] README entries/content
- [ ] Go CLI/tooling
- [ ] GitHub workflows or `.github` docs

## If This PR Adds/Edits README Entries

- Category/section touched: User Interfaces → Terminal
- New or updated project links: https://github.com/deveshctl/layerx

## Validation

- [x] `make lint`
- [ ] `make test` (if Go code changed)
- [ ] `./awesome-docker check` (if `GITHUB_TOKEN` available)