### PR TITLE
Add DockPier — auto-discovery dashboard for Docker container web UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [Arcane](https://github.com/getarcaneapp/arcane) - An easy and modern Docker management platform, built with everybody in mind.
 - [CASA](https://github.com/knrdl/casa) - Outsource the administration of a handful of containers to your co-workers,.
 - [Container Web TTY](https://github.com/wrfly/container-web-tty) - Connect your containers via a web-tty.
+- [DockPier](https://github.com/abakermi/dockpier) - Auto-discovers Docker containers and their web UIs from labels, published ports, and reverse proxy configs. Multi-host with real-time updates.
 - [Docker Registry Browser](https://github.com/klausmeyer/docker-registry-browser) - Web Interface for the Docker Registry HTTP API v2.
 - [docker-swarm-visualizer](https://github.com/dockersamples/docker-swarm-visualizer) - Visualizes Docker services on a Docker Swarm (for running demos).
 - [dockge](https://github.com/louislam/dockge) - Easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.


### PR DESCRIPTION
## What this adds

Adds [DockPier](https://github.com/abakermi/dockpier) to the **User Interfaces > Web** section.

## "For Docker" test

> *"This project exists to auto-discover Docker containers and their web UIs from the Docker socket/API."*

If you removed Docker, DockPier has no reason to exist. It connects directly to the Docker daemon (socket, TCP+TLS, SSH), reads container labels and events, and resolves web UIs from:
- `dockpier.*` Docker labels
- Traefik router rules
- nginx-proxy `VIRTUAL_HOST`
- Caddy labels
- Well-known image → port mappings (50+)
- Published port fallback

Without Docker integration, the project is nothing.

## Entry details

- **Section:** User Interfaces > Web
- **Alphabetical position:** between Container Web TTY and Docker Registry Browser
- **Active:** created and maintained in 2026
- **License:** MIT
- **Multi-arch Docker image on GHCR** (amd64 + arm64)

## Entry

```
- [DockPier](https://github.com/abakermi/dockpier) - Auto-discovers Docker containers and their web UIs from labels, published ports, and reverse proxy configs. Multi-host with real-time updates.
```