### PR TITLE
Add Spwig to awesome-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,3 +665,4 @@ Tools and applications that are either installed inside containers or designed t
 [openshift]: https://okd.io/
 [sindresorhus]: https://github.com/sindresorhus/awesome
 
+- [Spwig](https://github.com/Spwig/commerce) - Self-hosted e-commerce platform with Docker deployment, full ownership of code, data, and customers.


### PR DESCRIPTION
Spwig is a self-hosted e-commerce platform built for merchants and agencies who want full control over their commerce stack. It fits this list because it is tightly integrated with Docker for deployment and operation, with a one-line installer and Docker Compose support. I have followed the CONTRIBUTING guidelines, ensuring alphabetical placement and a concise description that aligns with the list's focus on Docker-centric tools.