### PR TITLE
Add Rasptele to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Monitor Docker hosts, containers, and the services running inside them. Self-hos
 - [Grafana Docker Dashboard Template](https://grafana.com/grafana/dashboards/179-docker-prometheus-monitoring/) - A template for your Docker, Grafana and Prometheus stack.
 - [Maintenant](https://github.com/kolapsis/maintenant) - Self-discovering infrastructure monitoring for Docker and Kubernetes. Auto-detects containers via labels, with endpoint monitoring, heartbeats, TLS certificates, resource metrics, update intelligence, and a built-in status page. Single binary with embedded SPA.
 - [Middleware](https://middleware.io/) - :yen: Monitor Docker hosts, containers, logs, and application performance from a unified observability platform.
+- [Rasptele](https://github.com/maddhruv/rasptele) - Monitor Docker containers and restart allowlisted services through a private Telegram bot, with stateful alerts and audit history.
 - [Site24x7](https://www.site24x7.com/docker-monitoring.html) - :yen: Docker Monitoring for DevOps and IT, SaaS Pay-per-Host model.
 - [Sysdig Monitor](https://www.sysdig.com/products/monitor) - :yen: Software or SaaS service that monitors, alerts, and troubleshoots containers using system calls; container-specific features for Docker and Kubernetes.
 - [Wiremap](https://github.com/codeofmario/wiremap) - A self-hosted visual Docker network topology explorer with real-time log streaming, live stats, embedded terminal, and container inspection.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

This project exists to monitor Docker containers and provide allowlisted container restarts through a private Telegram control plane.

What changed and why:

Added Rasptele to the Observability section. Rasptele integrates with the Docker API to report container status, perform allowlisted restarts, send stateful alerts, and retain an audit history, making it directly useful for remotely operating Docker hosts.

Validation:

- `git diff --check` passed.
- `make lint` was attempted, but the requested Go toolchain download could not complete because the local environment ran out of disk space. The submitted diff contains one alphabetically placed README entry.
