### PR TITLE
Add dii to Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Applications designed to help or simplify building **new** images
 - [buildx](https://github.com/docker/buildx) - Official Docker CLI plugin for multi-platform builds backed by BuildKit.
 - [cekit](https://github.com/cekit/cekit) - A tool used by openshift to build base images using different build engines.
 - [dlayer](https://github.com/orisano/dlayer) - Docker layer analyzer.
+- [dii](https://github.com/DDDPS/dii) - Extract and filter essential runtime configurations (ENV, ports, volumes, etc.) from Docker and OCI images, with Docker Compose generation.
 - [docker-companion](https://github.com/mudler/docker-companion) - A command line tool written in Golang to squash and unpack docker images.
 - [docker-repack](https://github.com/orf/docker-repack) - Repacks a Docker image into a smaller, more efficient version that makes it significantly faster to pull.
 - [DockerSlim](https://github.com/docker-slim/docker-slim) shrinks fat Docker images creating the smallest possible images.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Applications designed to help or simplify building **new** images
 - [BuildKit](https://github.com/moby/buildkit) - Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit.
 - [buildx](https://github.com/docker/buildx) - Official Docker CLI plugin for multi-platform builds backed by BuildKit.
 - [cekit](https://github.com/cekit/cekit) - A tool used by openshift to build base images using different build engines.
-- [dlayer](https://github.com/orisano/dlayer) - Docker layer analyzer.
 - [dii](https://github.com/DDDPS/dii) - Extract and filter essential runtime configurations (ENV, ports, volumes, etc.) from Docker and OCI images, with Docker Compose generation.
+- [dlayer](https://github.com/orisano/dlayer) - Docker layer analyzer.
 - [docker-companion](https://github.com/mudler/docker-companion) - A command line tool written in Golang to squash and unpack docker images.
 - [docker-repack](https://github.com/orf/docker-repack) - Repacks a Docker image into a smaller, more efficient version that makes it significantly faster to pull.
 - [DockerSlim](https://github.com/docker-slim/docker-slim) shrinks fat Docker images creating the smallest possible images.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

Write the sentence: *"This project exists to extract and filter essential runtime configurations from Docker and OCI images."*

If the blank doesn't contain **Docker, container, image, registry, Dockerfile, Compose, Swarm, BuildKit, or OCI**, it probably doesn't belong here.

What changed and why:

Added [dii](https://github.com/DDDPS/dii) to Building Images - Builder

`dii` is a lightweight Go-based CLI tool designed to inspect, extract, and filter essential runtime configurations (ENVs, ports, volume mounts, etc.) from Docker and OCI images via local Daemon, remote Registries, or offline tarballs, with support for exporting them as Docker Compose files.
