### PR TITLE
Add Nutilz Dockerfile Generator to Dockerfile list

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Minimal, hardened, or purpose-built container base images.
 - [Dockerfile Generator](https://github.com/ozankasikci/dockerfile-generator) `dfg` is both a Go library and an executable that produces valid Dockerfiles using various input channels.
 - [Dockershelf](https://github.com/Dockershelf/dockershelf) - A repository that serves as a collector for docker recipes that are universal, efficient and slim. Images are updated, tested and published daily via a Travis cron job.
 - [Dofigen](https://github.com/lenra-io/dofigen) - A Dockerfile generator using a simplified description in YAML or JSON format.
+- [Nutilz Dockerfile Generator](https://nutilz.com/dockerfile-generator) - Free browser-based generator that produces production-ready Dockerfiles from stack presets (Node/Express, Next.js, Python/FastAPI, and more) with multi-stage builds, non-root users, and healthchecks baked in.
 - [Trsuted Builds](https://dockerfile.github.io/) - Trusted Automated Docker Builds. Dockerfile Project maintains a central repository of Dockerfile for various popular open source software services runnable on a Docker container.
 
 ### Linter


### PR DESCRIPTION
Adds [Nutilz Dockerfile Generator](https://nutilz.com/dockerfile-generator) to the Dockerfile section, alongside the existing Dockerfile Generator / Dofigen entries.

What it is: a free, no-signup browser tool that generates production-ready Dockerfiles from common stack presets (Node/Express, Next.js, Python/FastAPI, and others), with multi-stage builds, non-root users, and healthchecks included by default.

Entry placed in alphabetical order per the existing list convention.