### PR TITLE
Add Nutilz Docker Compose Generator to Composition list

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Signing, attestation, and provenance for container images.
 - [Composerize](https://github.com/magicmark/composerize) - Convert docker run commands into docker-compose files.
 - [ctk](https://github.com/ctk-hq/ctk) - Visual composer for container based workloads.
 - [kompose](https://github.com/kubernetes/kompose) - Go from Docker Compose to Kubernetes.
+- [Nutilz Docker Compose Generator](https://nutilz.com/docker-compose-generator) - Free browser-based visual builder for docker-compose.yml with multi-service stack presets (Node/Express, Django/FastAPI, MERN, WordPress, Go microservices), env vars, volumes, healthchecks, and built-in lint validation.
 - [plash](https://github.com/ihucos/plash) - A container run and build engine - runs inside docker.
 - [podman-compose](https://github.com/containers/podman-compose) - A script to run docker-compose.yml using podman.
 - [Smalte](https://github.com/roquie/smalte) – Dynamically configure applications that require static configuration in docker container.


### PR DESCRIPTION
Adds [Nutilz Docker Compose Generator](https://nutilz.com/docker-compose-generator), a free browser-based visual builder for docker-compose.yml. Generates multi-service stack presets (Node/Express, Next.js, Django/FastAPI, MERN, WordPress, Go microservices), configures env vars, volumes, networks, and healthchecks, and includes built-in lint validation for common compose mistakes (port collisions, missing volumes, circular depends_on). 100% client-side — no data uploaded or stored server-side.

Added to the Composition section alongside Composerize, matching the existing entry format and alphabetical order.