### PR TITLE
Add Nutilz Docker Compose Generator to Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Signing, attestation, and provenance for container images.
 - [Composerize](https://github.com/magicmark/composerize) - Convert docker run commands into docker-compose files.
 - [ctk](https://github.com/ctk-hq/ctk) - Visual composer for container based workloads.
 - [kompose](https://github.com/kubernetes/kompose) - Go from Docker Compose to Kubernetes.
+- [Nutilz Docker Compose Generator](https://nutilz.com/docker-compose-generator) - Free browser-based visual builder for docker-compose.yml with multi-service presets, env vars, volumes, networks & healthchecks, plus built-in lint validation.
 - [plash](https://github.com/ihucos/plash) - A container run and build engine - runs inside docker.
 - [podman-compose](https://github.com/containers/podman-compose) - A script to run docker-compose.yml using podman.
 - [Smalte](https://github.com/roquie/smalte) – Dynamically configure applications that require static configuration in docker container.


### PR DESCRIPTION
Adds [Nutilz Docker Compose Generator](https://nutilz.com/docker-compose-generator), a free, browser-based visual builder for docker-compose.yml files. It offers multi-service presets (Node/Postgres/Redis/Nginx, FastAPI/Celery, MERN stack, WordPress, etc.), a form UI for services/ports/env vars/volumes/networks/healthchecks, and built-in lint validation before you export the YAML. No signup required, runs entirely in the browser.

Added alphabetically under Running Containers > Composition, alongside similar tools like Composerize and ctk.