### PR TITLE
Add Granite Registry to the Registry section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Services to securely store your Docker images.
 - [Gitea Container Registry](https://docs.gitea.com/usage/packages/container) - Integrated Docker registry in Gitea, ideal for private, small-scale image hosting.
 - [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) - GitHub's solution for storing and managing Docker images, with tight integration into GitHub Actions.
 - [GitLab Container Registry](https://docs.gitlab.com/user/packages/container_registry/) - Registry focused on using its images in GitLab CI.
+- [Granite Registry](https://granite.so/products/docker-registry) - :yen: Store private Docker images alongside the workloads that pull them, with scoped read-only and read-write keys.
 - [Harbor](https://github.com/goharbor/harbor) An open source trusted cloud native registry project that stores, signs, and scans content. Supports replication, user management, access control and activity auditing.
 - [JFrog Artifactory](https://jfrog.com/artifactory/) - :yen: Artifact Repository Manager, can be used as private Docker Registry as well.
 - [kontain.me](https://github.com/imjasonh/kontain.me) - On-demand container image registry that builds and serves images when they are pulled.


### PR DESCRIPTION

Adds a managed private Docker registry to `### Registry`.

```
- [Granite Registry](https://granite.so/products/docker-registry) - :yen: Store private Docker images alongside the workloads that pull them, with scoped read-only and read-write keys.
```

### The "for Docker" test

I want to be upfront, because the honest answer is different depending on what is being submitted.

Granite as a whole is an application platform, and it **fails** your test — take Docker away and it is still a Git-deploy PaaS. So I am not submitting the platform, and not proposing an entry in `Deployment & Platforms`.

What I am submitting is its registry. *"This project exists to store and serve private Docker images."* Remove Docker and there is nothing left, and your guidelines name `registry` in the accept list directly. Its peers in this section — ECR, Azure Container Registry, Cloudsmith, GCP Artifact Registry, JFrog — are the same shape: commercial managed registries linking to a product page.

### Entry rules

- One link per entry.
- `:yen:` set, it is a paid service (from $9/month, no free tier).
- Inserted alphabetically between GitLab Container Registry and Harbor, case-insensitive.
- One sentence, leads with the verb, and the Docker connection is in the description rather than implied.
- Links to the product page rather than a repository — the service is not open source, so there is no repo to point at. Same as the other commercial entries in this section.
- Active: in open beta since October 2025, shipping monthly.

### What it does

Plain Docker protocol, no special client — `docker login`, `docker push`, `docker pull` and any existing CI job work unchanged. Private by default: nothing is listed or published, and every pull and push needs a key you issued. Keys come in read-only and read-write-delete, revocable one at a time. No cap on repositories or images. Images are pulled from inside the platform that runs them, and pushing a tag can trigger a redeploy.

### Disclosure

I work on Granite, so this is a self-submission. Flagging it rather than leaving you to notice.

This PR was assisted by AI (Claude): finding the right section, checking the entry rules against the guidelines and drafting this description. The claims above are mine and are all verifiable on the linked page.

`make lint` passes locally.
