### PR TITLE
Add Docker Commander to Web UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [Arcane](https://github.com/getarcaneapp/arcane) - An easy and modern Docker management platform, built with everybody in mind.
 - [CASA](https://github.com/knrdl/casa) - Outsource the administration of a handful of containers to your co-workers,.
 - [Container Web TTY](https://github.com/wrfly/container-web-tty) - Connect your containers via a web-tty.
+- [Docker Commander](https://github.com/koduj-dev/docker-commander) - A self-hosted Docker management and monitoring UI with multi-host support, Compose management, aggregated logs, alerts, RBAC, vulnerability scanning, and MCP integration.
 - [Docker Registry Browser](https://github.com/klausmeyer/docker-registry-browser) - Web Interface for the Docker Registry HTTP API v2.
 - [docker-swarm-visualizer](https://github.com/dockersamples/docker-swarm-visualizer) - Visualizes Docker services on a Docker Swarm (for running demos).
 - [dockge](https://github.com/louislam/dockge) - Easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.


### PR DESCRIPTION
- [x] I HAVE READ .github/CONTRIBUTING.md

This project exists to manage and monitor Docker containers, images, networks, volumes, and Compose projects through a self-hosted web interface.

What changed and why:

Added Docker Commander to the Web UI section because it is specifically built for Docker management and monitoring, including container lifecycle control, Compose management, multi-host support, logs, alerts, RBAC, vulnerability scanning, and MCP integration.