### PR TITLE
Add Docker Ready Proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Tools and applications that are either installed inside containers or designed t
 - [Docker for beginners](https://github.com/groda/big_data/blob/master/docker_for_beginners.md): A tutorial for beginners who need to learn the basics of Docker—from "Hello world!" to basic interactions with containers, with simple explanations of the underlying concepts.
 - [Docker for novices](https://www.youtube.com/watch?v=xsjSadjKXns) An introduction to Docker for developers and testers who have never used it. (Video 1h40, recorded linux.conf.au 2019 — Christchurch, New Zealand)
 - [Docker katas](https://github.com/eficode-academy/docker-katas) A series of labs that will take you from "Hello Docker" to deploying a containerized web application to a server.
+- [Docker Ready Proof](https://github.com/canilbey/docker-ready-proof) - :yen: Demonstrates a tested Docker and Compose baseline with a non-root, read-only runtime, health checks, restart verification, and CI acceptance evidence.
 - [Docker simplified in 55 seconds](https://www.youtube.com/watch?v=vP_4DlOH1G4): An animated high-level introduction to Docker. Think of it as a visual tl;dr that makes it easier to dive into more complex learning materials.
 - [Docker Training](https://training.mirantis.com) - :yen:
 - [Dockerlings](https://github.com/furkan/dockerlings): Learn docker from inside your terminal, with a modern TUI and bite sized exercises.


### PR DESCRIPTION
- [x] I HAVE READ .github/CONTRIBUTING.md

This project exists to demonstrate a reproducible Docker and Compose readiness baseline with observable CI acceptance checks.

What changed and why:

- Adds Docker Ready Proof to **Learning Resources → Where to Start** as a tested reference implementation.
- The repository demonstrates Docker-specific behavior: image build, Compose startup, non-root/read-only runtime, health checks, endpoint smoke tests, and restart verification.
- I maintain the submitted repository. Its public technical proof is MIT-licensed, while its README also links a paid fixed-scope service offer; the entry therefore discloses this with `:yen:`.
- The change is one alphabetically placed README entry and the URL was not already listed.

Validation:

- `git diff --check`: passed
- URL uniqueness and `:yen:` assertion: passed
- `make build && make lint` in `golang:1.26.3-bookworm`: passed (`OK: 0 warnings`)
