### PR TITLE
feat: add DockScope to Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ TUIs, CLI tools, and shell integrations for Docker.
 - [Docker Registry Browser](https://github.com/klausmeyer/docker-registry-browser) - Web Interface for the Docker Registry HTTP API v2.
 - [docker-swarm-visualizer](https://github.com/dockersamples/docker-swarm-visualizer) - Visualizes Docker services on a Docker Swarm (for running demos).
 - [dockge](https://github.com/louislam/dockge) - Easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.
+- [DockScope](https://github.com/ManuelR-T/dockscope) - Visualizes Docker containers in a 3D dependency graph with live metrics, logs, and an in-browser terminal.
 - [Komodo](https://github.com/mbecker20/komodo) - A tool to build and deploy software on many servers.
 - [Portainer](https://github.com/portainer/portainer) - A lightweight management UI for managing your Docker hosts or Docker Swarm clusters.
 - [Swarmpit](https://github.com/swarmpit/swarmpit) - Swarmpit provides simple and easy to use interface for your Docker Swarm cluster. You can manage your stacks, services, secrets, volumes, networks etc.


### PR DESCRIPTION
# IF THE PROJECT JUST RUNS IN DOCKER, AUTOMATICALLY DENIED

- [x] I HAVE READ .github/CONTRIBUTING.md

## Write the sentence: *"This project exists to ____."*

This project exists to visualize and manage Docker containers: a 3D dependency graph, live metrics, logs, and container actions.

## What changed and why:

Added [DockScope](https://github.com/ManuelR-T/dockscope) to User Interfaces > Web. It's a Docker dashboard that visualizes running containers as a 3D dependency graph alongside live metrics, logs, an in-browser terminal, and container actions, same category as `Portainer`/`dockge`/`Arcane` already listed there.

## Testing:

- `make lint`