### PR TITLE
fix(ci): add marcuslonnberg/sbt-docker to exclude list

### DIFF
--- a/config/exclude.yaml
+++ b/config/exclude.yaml
@@ -17,3 +17,4 @@ domains:
   - https://www.aquasec.com
   - https://cloudsmith.com
   - https://pythonspeed.com/
+  - https://github.com/marcuslonnberg/sbt-docker


### PR DESCRIPTION
### Summary of Changes
Adds `https://github.com/marcuslonnberg/sbt-docker` to `config/exclude.yaml`.

### Context & Motivation
During the automated `broken-links` workflow run, the GitHub API returned a transient `504 Gateway Timeout` when validating queries against the `marcuslonnberg/sbt-docker` repository. The target repository remains active and accessible, making this a false-positive CI failure.

Excluding this URL prevents recurrent automated build/check failures caused by API latency.

Closes #1530